### PR TITLE
Elasticsearch 5 compatibility with new fields

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,27 +5,42 @@ language: python
 python:
   - "3.6"
 
+dist: trusty # default "precise" distro doesn't include Java 8 for Elasticsearch 5
+
 env:
-  - TOX_ENV=py35-django-18
-  - TOX_ENV=py34-django-18
-  - TOX_ENV=py27-django-18
-  - TOX_ENV=py35-django-19
-  - TOX_ENV=py34-django-19
-  - TOX_ENV=py27-django-19
-  - TOX_ENV=py36-django-110
-  - TOX_ENV=py35-django-110
-  - TOX_ENV=py34-django-110
-  - TOX_ENV=py27-django-110
-  - TOX_ENV=py36-django-111
-  - TOX_ENV=py35-django-111
-  - TOX_ENV=py34-django-111
-  - TOX_ENV=py27-django-111
+  - TOX_ENV=py35-django-18-es2 ES_APT_URL=https://packages.elastic.co/elasticsearch/2.x/debian
+  - TOX_ENV=py35-django-18-es5 ES_APT_URL=https://artifacts.elastic.co/packages/5.x/apt
+  - TOX_ENV=py34-django-18-es2 ES_APT_URL=https://packages.elastic.co/elasticsearch/2.x/debian
+  - TOX_ENV=py34-django-18-es5 ES_APT_URL=https://artifacts.elastic.co/packages/5.x/apt
+  - TOX_ENV=py27-django-18-es2 ES_APT_URL=https://packages.elastic.co/elasticsearch/2.x/debian
+  - TOX_ENV=py27-django-18-es5 ES_APT_URL=https://artifacts.elastic.co/packages/5.x/apt
+  - TOX_ENV=py35-django-19-es2 ES_APT_URL=https://packages.elastic.co/elasticsearch/2.x/debian
+  - TOX_ENV=py35-django-19-es5 ES_APT_URL=https://artifacts.elastic.co/packages/5.x/apt
+  - TOX_ENV=py34-django-19-es2 ES_APT_URL=https://packages.elastic.co/elasticsearch/2.x/debian
+  - TOX_ENV=py34-django-19-es5 ES_APT_URL=https://artifacts.elastic.co/packages/5.x/apt
+  - TOX_ENV=py27-django-19-es2 ES_APT_URL=https://packages.elastic.co/elasticsearch/2.x/debian
+  - TOX_ENV=py27-django-19-es5 ES_APT_URL=https://artifacts.elastic.co/packages/5.x/apt
+  - TOX_ENV=py36-django-110-es2 ES_APT_URL=https://packages.elastic.co/elasticsearch/2.x/debian
+  - TOX_ENV=py36-django-110-es5 ES_APT_URL=https://artifacts.elastic.co/packages/5.x/apt
+  - TOX_ENV=py35-django-110-es2 ES_APT_URL=https://packages.elastic.co/elasticsearch/2.x/debian
+  - TOX_ENV=py35-django-110-es5 ES_APT_URL=https://artifacts.elastic.co/packages/5.x/apt
+  - TOX_ENV=py34-django-110-es2 ES_APT_URL=https://packages.elastic.co/elasticsearch/2.x/debian
+  - TOX_ENV=py34-django-110-es5 ES_APT_URL=https://artifacts.elastic.co/packages/5.x/apt
+  - TOX_ENV=py27-django-110-es2 ES_APT_URL=https://packages.elastic.co/elasticsearch/2.x/debian
+  - TOX_ENV=py27-django-110-es5 ES_APT_URL=https://artifacts.elastic.co/packages/5.x/apt
+  - TOX_ENV=py36-django-111-es2 ES_APT_URL=https://packages.elastic.co/elasticsearch/2.x/debian
+  - TOX_ENV=py36-django-111-es5 ES_APT_URL=https://artifacts.elastic.co/packages/5.x/apt
+  - TOX_ENV=py35-django-111-es2 ES_APT_URL=https://packages.elastic.co/elasticsearch/2.x/debian
+  - TOX_ENV=py35-django-111-es5 ES_APT_URL=https://artifacts.elastic.co/packages/5.x/apt
+  - TOX_ENV=py34-django-111-es2 ES_APT_URL=https://packages.elastic.co/elasticsearch/2.x/debian
+  - TOX_ENV=py34-django-111-es5 ES_APT_URL=https://artifacts.elastic.co/packages/5.x/apt
+  - TOX_ENV=py27-django-111-es2 ES_APT_URL=https://packages.elastic.co/elasticsearch/2.x/debian
+  - TOX_ENV=py27-django-111-es5 ES_APT_URL=https://artifacts.elastic.co/packages/5.x/apt
 
 before_install:
   - pip install codecov
-  - sudo apt-get autoremove --purge elasticsearch
   - wget -qO - https://packages.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -
-  - echo "deb http://packages.elastic.co/elasticsearch/2.x/debian stable main" | sudo tee -a /etc/apt/sources.list.d/elk.list
+  - echo "deb $ES_APT_URL stable main" | sudo tee -a /etc/apt/sources.list.d/elk.list
   - sudo apt-get update && sudo apt-get install elasticsearch -y
   - sudo service elasticsearch start
 

--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ Features
 - Requirements
    - Django >= 1.8
    - Python 2.7, 3.4, 3.5
-   - Elasticsearch >= 2.1,<=5.1.0
+   - Elasticsearch >= 2.1
 
 .. _Search: http://elasticsearch-dsl.readthedocs.io/en/stable/search_dsl.html
 

--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ Features
 - Requirements
    - Django >= 1.8
    - Python 2.7, 3.4, 3.5
-   - Elasticsearch >= 2.1
+   - Elasticsearch >= 2.1,<=5.1.0
 
 .. _Search: http://elasticsearch-dsl.readthedocs.io/en/stable/search_dsl.html
 

--- a/django_elasticsearch_dsl/__init__.py
+++ b/django_elasticsearch_dsl/__init__.py
@@ -4,18 +4,25 @@ from .documents import DocType  # noqa
 from .indices import Index  # noqa
 from .signals import delete_document, update_document # noqa
 from .fields import (  # noqa
-    StringField,
-    FloatField,
-    DoubleField,
-    ByteField,
-    ShortField,
-    IntegerField,
-    LongField,
-    DateField,
+    AttachmentField,
     BooleanField,
-    ObjectField,
-    NestedField,
+    ByteField,
+    CompletionField,
+    DateField,
+    DoubleField,
+    FloatField,
+    GeoPointField,
+    GeoShapeField,
+    IntegerField,
+    IpField,
+    KeywordField,
     ListField,
+    LongField,
+    NestedField,
+    ObjectField,
+    ShortField,
+    StringField,
+    TextField,
 )
 
 __version__ = '0.1.0'

--- a/django_elasticsearch_dsl/fields.py
+++ b/django_elasticsearch_dsl/fields.py
@@ -2,19 +2,40 @@ import collections
 from types import MethodType
 
 from django.db import models
-
 from elasticsearch_dsl.field import (
     Boolean,
     Date,
     Field,
-    FIELDS,
-    Object,
     Nested,
-    String
+    Object,
+    String,
 )
-from elasticsearch_dsl.utils import _make_dsl_class
-
 from .exceptions import VariableLookupError
+
+FIELDS = (
+    'float',
+    'double',
+    'byte',
+    'short',
+    'integer',
+    'long',
+    'ip',
+    'attachment',
+    'geo_point',
+    'geo_shape',
+    'completion',
+)
+
+
+def _make_dsl_class(base, name, params_def=None, suffix=''):
+    """
+    Generate a DSL class based on the name of the DSL object and it's parameters
+    """
+    attrs = {'name': name}
+    if params_def:
+        attrs['_param_defs'] = params_def
+    cls_name = str(''.join(s.title() for s in name.split('_')) + suffix)
+    return type(cls_name, (base, ), attrs)
 
 
 class DEDField(Field):

--- a/django_elasticsearch_dsl/fields.py
+++ b/django_elasticsearch_dsl/fields.py
@@ -3,39 +3,27 @@ from types import MethodType
 
 from django.db import models
 from elasticsearch_dsl.field import (
+    Attachment,
     Boolean,
+    Byte,
+    Completion,
     Date,
+    Double,
     Field,
+    Float,
+    GeoPoint,
+    GeoShape,
+    Integer,
+    Ip,
+    Keyword,
+    Long,
     Nested,
     Object,
+    Short,
     String,
+    Text,
 )
 from .exceptions import VariableLookupError
-
-FIELDS = (
-    'float',
-    'double',
-    'byte',
-    'short',
-    'integer',
-    'long',
-    'ip',
-    'attachment',
-    'geo_point',
-    'geo_shape',
-    'completion',
-)
-
-
-def _make_dsl_class(base, name, params_def=None, suffix=''):
-    """
-    Generate a DSL class based on the name of the DSL object and it's parameters
-    """
-    attrs = {'name': name}
-    if params_def:
-        attrs['_param_defs'] = params_def
-    cls_name = str(''.join(s.title() for s in name.split('_')) + suffix)
-    return type(cls_name, (base, ), attrs)
 
 
 class DEDField(Field):
@@ -90,18 +78,6 @@ class DEDField(Field):
         return instance
 
 
-class StringField(DEDField, String):
-    pass
-
-
-class BooleanField(DEDField, Boolean):
-    pass
-
-
-class DateField(DEDField, Date):
-    pass
-
-
 class ObjectField(DEDField, Object):
     def _get_inner_field_data(self, obj):
         data = {}
@@ -127,10 +103,6 @@ class ObjectField(DEDField, Object):
         return self._get_inner_field_data(objs)
 
 
-class NestedField(Nested, ObjectField):
-    pass
-
-
 def ListField(field):
     """
     This wraps a field so that when get_value_from_instance
@@ -145,6 +117,69 @@ def ListField(field):
     return field
 
 
-for f in FIELDS:
-    fclass = _make_dsl_class(DEDField, f, suffix="Field")
-    globals()[fclass.__name__] = fclass
+class AttachmentField(DEDField, Attachment):
+    pass
+
+
+class BooleanField(DEDField, Boolean):
+    pass
+
+
+class ByteField(DEDField, Byte):
+    pass
+
+
+class CompletionField(DEDField, Completion):
+    pass
+
+
+class DateField(DEDField, Date):
+    pass
+
+
+class DoubleField(DEDField, Double):
+    pass
+
+
+class FloatField(DEDField, Float):
+    pass
+
+
+class GeoPointField(DEDField, GeoPoint):
+    pass
+
+
+class GeoShapeField(DEDField, GeoShape):
+    pass
+
+
+class IntegerField(DEDField, Integer):
+    pass
+
+
+class IpField(DEDField, Ip):
+    pass
+
+
+class KeywordField(DEDField, Keyword):
+    pass
+
+
+class LongField(DEDField, Long):
+    pass
+
+
+class NestedField(Nested, ObjectField):
+    pass
+
+
+class ShortField(DEDField, Short):
+    pass
+
+
+class StringField(DEDField, String):
+    pass
+
+
+class TextField(DEDField, Text):
+    pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 django>=1.9.6
-elasticsearch-dsl>=2.0.0,<=5.1.0
+elasticsearch-dsl>=2.0.0,<=5.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 django>=1.9.6
-elasticsearch-dsl>=2.0.0,<3.0.0
+elasticsearch-dsl>=2.0.0,<=5.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 django>=1.9.6
-elasticsearch-dsl>=2.0.0,<=5.3.0
+elasticsearch-dsl>=2.0.0,<6.0.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,5 @@
 bumpversion==0.5.3
 wheel==0.29.0
 django>=1.11
-elasticsearch-dsl>=2.0.0,<3.0.0
+elasticsearch-dsl>=2.0.0,<6.0.0
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,3 @@
-elasticsearch-dsl>=2.0.0,<6.0.0
 coverage==4.1
 mock>=1.0.1
 flake8>=2.1.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,4 @@
-elasticsearch-dsl>=2.0.0,<=5.3.0
+elasticsearch-dsl>=2.0.0,<6.0.0
 coverage==4.1
 mock>=1.0.1
 flake8>=2.1.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,4 @@
-elasticsearch-dsl>=2.0.0,<3.0.0
+elasticsearch-dsl>=2.0.0,<=5.1.0
 coverage==4.1
 mock>=1.0.1
 flake8>=2.1.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,4 @@
-elasticsearch-dsl>=2.0.0,<=5.1.0
+elasticsearch-dsl>=2.0.0,<=5.3.0
 coverage==4.1
 mock>=1.0.1
 flake8>=2.1.0

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
-        'elasticsearch-dsl>=2.0.0,<=5.1.0',
+        'elasticsearch-dsl>=2.0.0,<6.0.0',
     ],
     license="Apache Software License 2.0",
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
-        'elasticsearch-dsl>=2.0.0,<3.0.0',
+        'elasticsearch-dsl>=2.0.0,<=5.1.0',
     ],
     license="Apache Software License 2.0",
     zip_safe=False,

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -2,21 +2,25 @@ from unittest import TestCase
 from mock import Mock, NonCallableMock
 from django_elasticsearch_dsl.fields import (
     DEDField,
-    ObjectField,
-    NestedField,
-    IntegerField,
+    AttachmentField,
+    BooleanField,
     ByteField,
-    LongField,
+    CompletionField,
+    DateField,
     DoubleField,
     FloatField,
-    BooleanField,
-    DateField,
-    StringField,
-    ListField,
-    CompletionField,
     GeoPointField,
     GeoShapeField,
+    IntegerField,
     IpField,
+    KeywordField,
+    ListField,
+    LongField,
+    NestedField,
+    ObjectField,
+    ShortField,
+    StringField,
+    TextField,
 )
 from django_elasticsearch_dsl.exceptions import VariableLookupError
 
@@ -293,3 +297,39 @@ class ListFieldTestCase(TestCase):
         field = ListField(StringField(attr='foo.bar'))
         self.assertEqual(
             field.get_value_from_instance(instance), instance.foo.bar)
+
+
+class TextFieldTestCase(TestCase):
+    def test_get_mapping(self):
+        field = TextField()
+
+        self.assertEqual({
+            'type': 'text',
+        }, field.to_dict())
+
+
+class KeywordFieldTestCase(TestCase):
+    def test_get_mapping(self):
+        field = KeywordField()
+
+        self.assertEqual({
+            'type': 'keyword',
+        }, field.to_dict())
+
+
+class AttachmentFieldTestCase(TestCase):
+    def test_get_mapping(self):
+        field = AttachmentField()
+
+        self.assertEqual({
+            'type': 'attachment',
+        }, field.to_dict())
+
+
+class ShortFieldTestCase(TestCase):
+    def test_get_mapping(self):
+        field = ShortField()
+
+        self.assertEqual({
+            'type': 'short',
+        }, field.to_dict())

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-    {py27,py34,py35,py36}-django-18
-    {py27,py34,py35,py36}-django-19
-    {py27,py34,py35,py36}-django-110
-    {py27,py34,py35,py36}-django-111
+    {py27,py34,py35,py36}-django-18-{es2,es5}
+    {py27,py34,py35,py36}-django-19-{es2,es5}
+    {py27,py34,py35,py36}-django-110-{es2,es5}
+    {py27,py34,py35,py36}-django-111-{es2,es5}
 
 [testenv]
 setenv =
@@ -16,6 +16,8 @@ deps =
     django-19: Django>=1.9,<1.10
     django-110: Django>=1.10,<1.11
     django-111: Django>=1.11
+    es2: elasticsearch-dsl>=2.0.0,<3.0.0
+    es5: elasticsearch-dsl>=5.0.0,<6.0.0
     -r{toxinidir}/requirements_test.txt
 
 basepython =


### PR DESCRIPTION
A continuation of the work from @markotibold , this PR includes not separate subclasses for fields rather than relying on the previously removed `_make_dsl_class` method. It also includes the TextField and KeywordField types for ES 5 compatibility.