### PR TITLE
Support defining DocType indexes through Meta class

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -12,4 +12,4 @@ Contributors
 ------------
 
 markotibold
-HansAdema
+HansAdema - Devhouse Spindle

--- a/django_elasticsearch_dsl/documents.py
+++ b/django_elasticsearch_dsl/documents.py
@@ -82,7 +82,7 @@ class DocTypeMeta(DSLDocTypeMeta):
 
         if getattr(cls._doc_type, 'index'):
             index = Index(cls._doc_type.index)
-            index.mapping(cls._doc_type.mapping)
+            index.doc_type(cls)
             registry.register(index, doc)
 
         return cls

--- a/django_elasticsearch_dsl/documents.py
+++ b/django_elasticsearch_dsl/documents.py
@@ -51,7 +51,6 @@ class DocTypeMeta(DSLDocTypeMeta):
         model = attrs['Meta'].model
         ignore_signals = getattr(attrs['Meta'], "ignore_signals", False)
         model_field_names = getattr(attrs['Meta'], "fields", [])
-        index = getattr(attrs['Meta'], 'index', None)
         class_fields = set(
             name for name, field in iteritems(attrs)
             if isinstance(field, Field)
@@ -63,9 +62,6 @@ class DocTypeMeta(DSLDocTypeMeta):
         cls._doc_type.ignore_signals = ignore_signals
 
         doc = cls()
-
-        if index:
-            registry.register(Index(index), doc)
 
         fields = model._meta.get_fields()
         fields_lookup = dict((field.name, field) for field in fields)
@@ -83,6 +79,12 @@ class DocTypeMeta(DSLDocTypeMeta):
 
         cls._doc_type._fields = (
             lambda: cls._doc_type.mapping.properties.properties.to_dict())
+
+        if getattr(cls._doc_type, 'index'):
+            index = Index(cls._doc_type.index)
+            index.mapping(cls._doc_type.mapping)
+            registry.register(index, doc)
+
         return cls
 
 

--- a/django_elasticsearch_dsl/registries.py
+++ b/django_elasticsearch_dsl/registries.py
@@ -15,8 +15,14 @@ class DocumentRegistry(object):
 
     def register(self, index, doc):
         """Register the model with the registry"""
-        self._indices[index].add(doc)
         self._models[doc._doc_type.model].add(doc)
+
+        for idx, docs in iteritems(self._indices):
+            if index._name == idx._name:
+                docs.add(doc)
+                return
+
+        self._indices[index].add(doc)
 
     def update(self, instance, **kwargs):
         """

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -6,6 +6,8 @@ from django.core.management import call_command
 from django.test import TestCase
 
 from django.utils.six import StringIO
+
+from django_elasticsearch_dsl import registries
 from django_elasticsearch_dsl.test import ESTestCase
 
 from .documents import CarDocument, AdDocument, ad_index, car_index
@@ -19,6 +21,8 @@ from .models import Car, Manufacturer, Ad, Category, COUNTRIES
 class IntegrationTestCase(ESTestCase, TestCase):
     def setUp(self):
         super(IntegrationTestCase, self).setUp()
+        registries.registry = registries.DocumentRegistry()
+
         self.manufacturer = Manufacturer(name="Peugeot",
                                          created=datetime(1900, 10, 9, 0, 0),
                                          country_code="FR")
@@ -235,6 +239,6 @@ class IntegrationTestCase(ESTestCase, TestCase):
         Ad(title="Ad title 3").save()
 
         call_command('search_index', action='populate',
-                     force=True, stdout=out)
+                     force=True, stdout=out, models=['tests.ad'])
         result = AdDocument().search().execute()
         self.assertEqual(len(result), 3)


### PR DESCRIPTION
Currently, DocType classes must be assigned to indexes using decorators. When setting the index property in the Meta class, the DocType will not be added to the registry.

This change makes it possible to do that.

It did require me to add additional checks to the registry to prevent the same name from being used multiple times.