### PR TITLE
Add options to disable automatic index refreshes.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,6 +107,7 @@ define in a ``documents.py`` file.
             ] # the fields of the model you want to be indexed in Elasticsearch
 
             # ignore_signals = True # To ignore auto updating of Elasticsearch when a model is save or delete
+            # auto_refresh = False  # Don't perform an index refresh after every update (overrides global setting)
 
 
 To create and populate the Elasticsearch index and mapping use the search_index command::
@@ -458,6 +459,13 @@ Default: ``True``
 
 Set to ``False`` to globally disable autosyncing.
 
+
+ELASTICSEARCH_DSL_AUTO_REFRESH
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Default: ``True``
+
+Set to ``False`` not force an [index refresh](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-refresh.html) with every save.
 
 Testing
 -------

--- a/django_elasticsearch_dsl/apps.py
+++ b/django_elasticsearch_dsl/apps.py
@@ -14,3 +14,7 @@ class DEDConfig(AppConfig):
     @classmethod
     def autosync_enabled(cls):
         return getattr(settings, 'ELASTICSEARCH_DSL_AUTOSYNC', True)
+
+    @classmethod
+    def auto_refresh_enabled(cls):
+        return getattr(settings, 'ELASTICSEARCH_DSL_AUTO_REFRESH', True)

--- a/django_elasticsearch_dsl/documents.py
+++ b/django_elasticsearch_dsl/documents.py
@@ -6,6 +6,7 @@ from elasticsearch_dsl.document import DocTypeMeta as DSLDocTypeMeta
 from elasticsearch_dsl.field import Field
 from elasticsearch_dsl import DocType as DSLDocType
 
+from .apps import DEDConfig
 from .exceptions import RedeclaredFieldError, ModelFieldNotMappedError
 from .fields import (
     DEDField,
@@ -57,6 +58,7 @@ class DocTypeMeta(DSLDocTypeMeta):
 
         model = attrs['Meta'].model
         ignore_signals = getattr(attrs['Meta'], "ignore_signals", False)
+        auto_refresh = getattr(attrs['Meta'], 'auto_refresh', DEDConfig.auto_refresh_enabled())
         model_field_names = getattr(attrs['Meta'], "fields", [])
         class_fields = set(
             name for name, field in iteritems(attrs)
@@ -67,6 +69,7 @@ class DocTypeMeta(DSLDocTypeMeta):
 
         cls._doc_type.model = model
         cls._doc_type.ignore_signals = ignore_signals
+        cls._doc_type.auto_refresh = auto_refresh
 
         doc = cls()
 
@@ -142,15 +145,16 @@ class DocType(DSLDocType):
                 "to an Elasticsearch field!".format(field_name)
             )
 
-    def bulk(self, actions, refresh=True, **kwargs):
-        return bulk(client=self.connection, actions=actions,
-                    refresh=refresh, **kwargs)
+    def bulk(self, actions, **kwargs):
+        return bulk(client=self.connection, actions=actions, **kwargs)
 
-    def update(self, thing, refresh=True, action='index', **kwargs):
+    def update(self, thing, refresh=None, action='index', **kwargs):
         """
         Update each document in ES for a model, iterable of models or queryset
         """
-        kwargs['refresh'] = refresh
+        if refresh is True or (refresh is None and self._doc_type.auto_refresh):
+            kwargs['refresh'] = True
+
         if isinstance(thing, models.Model):
             thing = [thing]
 

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -49,12 +49,22 @@ class DocTypeTestCase(TestCase):
     def test_ignore_signal_default(self):
         self.assertFalse(CarDocument._doc_type.ignore_signals)
 
+    def test_auto_refresh_default(self):
+        self.assertTrue(CarDocument._doc_type.auto_refresh)
+
     def test_ignore_signal_added(self):
         class Car2Document(DocType):
             class Meta:
                 model = Car
                 ignore_signals = True
         self.assertTrue(Car2Document._doc_type.ignore_signals)
+
+    def test_auto_refresh_added(self):
+        class Car3Document(DocType):
+            class Meta:
+                model = Car
+                auto_refresh = False
+        self.assertFalse(Car3Document._doc_type.auto_refresh)
 
     def test_fields_populated(self):
         mapping = CarDocument._doc_type.mapping
@@ -210,3 +220,11 @@ class DocTypeTestCase(TestCase):
             self.assertEqual(
                 doc.connection, mock.call_args_list[0][1]['client']
             )
+
+    def test_model_instance_update_no_refresh(self):
+        doc = CarDocument()
+        doc._doc_type.auto_refresh = False
+        car = Car()
+        with patch('django_elasticsearch_dsl.documents.bulk') as mock:
+            doc.update(car)
+            self.assertNotIn('refresh', mock.call_args_list[0][1])


### PR DESCRIPTION
With this change, you now have more options to disable automatic refreshes, in order of preference:

1. The `refresh` argument passed to the `DocType.update()` method.
2. The `auto_refresh` attribute defined in the DocType Meta class.
3. The `ELASTICSEARCH_DSL_AUTO_REFRESH` Django setting.
4. The default `True` value (for backwards compatibility).

Previously, it wasn't possible to prevent forced refreshes using the signals.

Fixes #26 