### PR TITLE
Remove `iterator()` from `search_index._populate()`

### DIFF
--- a/django_elasticsearch_dsl/documents.py
+++ b/django_elasticsearch_dsl/documents.py
@@ -116,8 +116,7 @@ class DocType(DSLDocType):
         """
         Return the queryset that should be indexed by this doc type.
         """
-        qs = self._doc_type.model._default_manager
-        return qs
+        return self._doc_type.model._default_manager.all()
 
     def prepare(self, instance):
         """

--- a/django_elasticsearch_dsl/management/commands/search_index.py
+++ b/django_elasticsearch_dsl/management/commands/search_index.py
@@ -89,7 +89,7 @@ class Command(BaseCommand):
             self.stdout.write("Indexing {} '{}' objects".format(
                 qs.count(), doc._doc_type.model.__name__)
             )
-            doc.update(qs.iterator())
+            doc.update(qs)
 
     def _delete(self, models, options):
         index_names = [str(index) for index in registry.get_indices(models)]

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -143,21 +143,13 @@ class SearchIndexTestCase(TestCase):
         ):
             call_command('search_index', stdout=self.out, action='populate')
             self.doc_a1.get_queryset.assert_called_once()
-            self.doc_a1.update.assert_called_once_with(
-                self.doc_a1_qs.iterator()
-            )
+            self.doc_a1.update.assert_called_once_with(self.doc_a1_qs)
             self.doc_a2.get_queryset.assert_called_once()
-            self.doc_a2.update.assert_called_once_with(
-                self.doc_a2_qs.iterator()
-            )
+            self.doc_a2.update.assert_called_once_with(self.doc_a2_qs)
             self.doc_b1.get_queryset.assert_called_once()
-            self.doc_b1.update.assert_called_once_with(
-                self.doc_b1_qs.iterator()
-            )
+            self.doc_b1.update.assert_called_once_with(self.doc_b1_qs)
             self.doc_c1.get_queryset.assert_called_once()
-            self.doc_c1.update.assert_called_once_with(
-                self.doc_c1_qs.iterator()
-            )
+            self.doc_c1.update.assert_called_once_with(self.doc_c1_qs)
 
     def test_rebuild_indices(self):
 

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -118,7 +118,7 @@ class DocTypeTestCase(TestCase):
 
     def test_get_queryset(self):
         qs = CarDocument().get_queryset()
-        self.assertIsInstance(qs, models.Manager)
+        self.assertIsInstance(qs, models.QuerySet)
         self.assertEqual(qs.model, Car)
 
     def test_prepare(self):


### PR DESCRIPTION
The use of `iterator()` in `search_index._populate()` breaks the usage of `prefetch_related`, which is useful to speed up indexing. I have not been able to find any advantage in using `iterator()`.

Fixes #27 