### PR TITLE
Replace simple model signals with easier to customise signal processors

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -474,6 +474,22 @@ Default: ``True``
 
 Set to ``False`` to globally disable auto-syncing.
 
+ELASTICSEARCH_DSL_SIGNAL_PROCESSOR
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This (optional) setting controls what SignalProcessor class is used to handle
+Django's signals and keep the search index up-to-date.
+
+An example:
+
+.. code-block:: python
+
+    ELASTICSEARCH_DSL_SIGNAL_PROCESSOR = 'django_elasticsearch_dsl.signals.RealTimeSignalProcessor'
+
+Defaults to ``django_elasticsearch_dsl.signals.RealTimeSignalProcessor``.
+
+You could, for instance, make a ``CelerySignalProcessor`` which would add
+update jobs to the queue to for delayed processing.
 
 Testing
 -------

--- a/django_elasticsearch_dsl/__init__.py
+++ b/django_elasticsearch_dsl/__init__.py
@@ -2,8 +2,7 @@ from django.utils.module_loading import autodiscover_modules
 
 from .documents import DocType  # noqa
 from .indices import Index  # noqa
-from .signals import delete_document, update_document # noqa
-from .fields import * # noqa
+from .fields import *  # noqa
 
 __version__ = '0.1.0'
 

--- a/django_elasticsearch_dsl/apps.py
+++ b/django_elasticsearch_dsl/apps.py
@@ -1,15 +1,28 @@
 from django.apps import AppConfig
-from elasticsearch_dsl.connections import connections
 from django.conf import settings
+
+from elasticsearch_dsl.connections import connections
+
+from .utils import import_class
 
 
 class DEDConfig(AppConfig):
     name = 'django_elasticsearch_dsl'
     verbose_name = "Django elasticsearch-dsl"
+    signal_processor = None
 
     def ready(self):
         self.module.autodiscover()
         connections.configure(**settings.ELASTICSEARCH_DSL)
+        # Setup the signal processor.
+        if not self.signal_processor:
+            signal_processor_path = getattr(
+                settings,
+                'ELASTICSEARCH_DSL_SIGNAL_PROCESSOR',
+                'django_elasticsearch_dsl.signals.RealTimeSignalProcessor'
+            )
+            signal_processor_class = import_class(signal_processor_path)
+            self.signal_processor = signal_processor_class(connections)
 
     @classmethod
     def autosync_enabled(cls):

--- a/django_elasticsearch_dsl/signals.py
+++ b/django_elasticsearch_dsl/signals.py
@@ -1,16 +1,77 @@
-from django.db.models.signals import post_save, post_delete
-from django.dispatch import receiver
+# encoding: utf-8
+"""
+A convenient way to attach django-elasticsearch-dsl to Django's signals and
+cause things to index.
+"""
+
+from __future__ import absolute_import
+
+from django.db import models
 
 from .registries import registry
 
 
-@receiver(post_save)
-def update_document(sender, **kwargs):
-    instance = kwargs['instance']
-    registry.update(instance)
+class BaseSignalProcessor(object):
+    """Base signal processor.
+
+    By default, does nothing with signals but provides underlying
+    functionality.
+    """
+
+    def __init__(self, connections):
+        self.connections = connections
+        self.setup()
+
+    def setup(self):
+        """Set up.
+
+        A hook for setting up anything necessary for
+        ``handle_save/handle_delete`` to be executed.
+
+        Default behavior is to do nothing (``pass``).
+        """
+        # Do nothing.
+
+    def teardown(self):
+        """Tear-down.
+
+        A hook for tearing down anything necessary for
+        ``handle_save/handle_delete`` to no longer be executed.
+
+        Default behavior is to do nothing (``pass``).
+        """
+        # Do nothing.
+
+    def handle_save(self, sender, **kwargs):
+        """Handle save.
+
+        Given an individual model instance, update the object in the index.
+        """
+        instance = kwargs['instance']
+        registry.update(instance)
+
+    def handle_delete(self, sender, **kwargs):
+        """Handle delete.
+
+        Given an individual model instance, delete the object from index.
+        """
+        instance = kwargs['instance']
+        registry.delete(instance, raise_on_error=False)
 
 
-@receiver(post_delete)
-def delete_document(sender, **kwargs):
-    instance = kwargs['instance']
-    registry.delete(instance, raise_on_error=False)
+class RealTimeSignalProcessor(BaseSignalProcessor):
+    """Real-time signal processor.
+
+    Allows for observing when saves/deletes fire and automatically updates the
+    search engine appropriately.
+    """
+
+    def setup(self):
+        # Listen to all model saves.
+        models.signals.post_save.connect(self.handle_save)
+        models.signals.post_delete.connect(self.handle_delete)
+
+    def teardown(self):
+        # Listen to all model saves.
+        models.signals.post_save.disconnect(self.handle_save)
+        models.signals.post_delete.disconnect(self.handle_delete)

--- a/django_elasticsearch_dsl/utils.py
+++ b/django_elasticsearch_dsl/utils.py
@@ -1,0 +1,16 @@
+import importlib
+
+
+def import_class(path):
+    """Import class by path given."""
+    path_bits = path.split('.')
+    # Cut off the class name at the end.
+    class_name = path_bits.pop()
+    module_path = '.'.join(path_bits)
+    module_itself = importlib.import_module(module_path)
+
+    if not hasattr(module_itself, class_name):
+        raise ImportError("The Python module '%s' has no '%s' class."
+                          "" % (module_path, class_name))
+
+    return getattr(module_itself, class_name)


### PR DESCRIPTION
I have been recently busy implementing an app to integrate Elasticsearch DSL with Django REST framework.

It turned into a [django-elasticsearch-dsl-drf](https://github.com/barseghyanartur/django-elasticsearch-dsl-drf) package, which make use of [django-elasticsearch-dsl](https://github.com/sabricot/django-elasticsearch-dsl/).

I want to avoid heavy signals in real time, but rather would add them to the queue to be processed later on.

Therefore - the introduction of signal processors.

At the moment, functionality remains intact, but leaves a place for handy replacement of real time index updates with custom ones (for instance, delayed update using Celery).