### PR TITLE
Add support for resynching ES documents if related models are updated

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -296,12 +296,17 @@ You can use an ObjectField or NestedField.
             'pk': fields.IntegerField(),
         })
 
+        def get_instances_from_related(self, instance):
+            """If related_models is set, define how to retrieve the Car instances from the related model."""
+            return instance.car_set.all()
+
         class Meta:
             model = Car
             fields = [
                 'name',
                 'color',
             ]
+            related_models = [Manufacturer]  # Optional: to ensure the Car will be re-saved when Manufacturer is updated
 
         # Not mandatory but to improve performance we can select related in
         # one sql request

--- a/django_elasticsearch_dsl/documents.py
+++ b/django_elasticsearch_dsl/documents.py
@@ -65,6 +65,7 @@ class DocTypeMeta(DSLDocTypeMeta):
             attrs['Meta'], 'auto_refresh', DEDConfig.auto_refresh_enabled()
         )
         model_field_names = getattr(attrs['Meta'], "fields", [])
+        related_models = getattr(attrs['Meta'], "related_models", [])
 
         class_fields = set(
             name for name, field in iteritems(attrs)
@@ -76,6 +77,7 @@ class DocTypeMeta(DSLDocTypeMeta):
         cls._doc_type.model = model
         cls._doc_type.ignore_signals = ignore_signals
         cls._doc_type.auto_refresh = auto_refresh
+        cls._doc_type.related_models = related_models
 
         doc = cls()
 

--- a/django_elasticsearch_dsl/registries.py
+++ b/django_elasticsearch_dsl/registries.py
@@ -41,8 +41,9 @@ class DocumentRegistry(object):
             if instance.__class__ in self._related_models:
                 for model in self._related_models[instance.__class__]:
                     for doc in self._models[model]:
-                        related_instances = doc.get_instances_from_related(instance)
-                        doc.update(related_instances, **kwargs)
+                        related = doc.get_instances_from_related(instance)
+                        if related:
+                            doc.update(related, **kwargs)
 
     def delete(self, instance, **kwargs):
         """

--- a/django_elasticsearch_dsl/registries.py
+++ b/django_elasticsearch_dsl/registries.py
@@ -18,15 +18,15 @@ class DocumentRegistry(object):
         """Register the model with the registry"""
         self._models[doc._doc_type.model].add(doc)
 
+        for related in doc._doc_type.related_models:
+            self._related_models[related].add(doc._doc_type.model)
+
         for idx, docs in iteritems(self._indices):
             if index._name == idx._name:
                 docs.add(doc)
                 return
 
         self._indices[index].add(doc)
-
-        for related in doc._doc_type.related_models:
-            self._related_models[related].add(doc._doc_type.model)
 
     def update(self, instance, **kwargs):
         """

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -29,21 +29,25 @@ class SearchIndexTestCase(TestCase):
 
         self.doc_a1 = Mock()
         self.doc_a1._doc_type.model = self.ModelA
+        self.doc_a1._doc_type.related_models = []
         self.doc_a1_qs = Mock()
         self.doc_a1.get_queryset = Mock(return_value=self.doc_a1_qs)
 
         self.doc_a2 = Mock()
         self.doc_a2._doc_type.model = self.ModelA
+        self.doc_a2._doc_type.related_models = []
         self.doc_a2_qs = Mock()
         self.doc_a2.get_queryset = Mock(return_value=self.doc_a2_qs)
 
         self.doc_b1 = Mock()
         self.doc_b1._doc_type.model = self.ModelB
+        self.doc_b1._doc_type.related_models = []
         self.doc_b1_qs = Mock()
         self.doc_b1.get_queryset = Mock(return_value=self.doc_b1_qs)
 
         self.doc_c1 = Mock()
         self.doc_c1._doc_type.model = self.ModelC
+        self.doc_c1._doc_type.related_models = []
         self.doc_c1_qs = Mock()
         self.doc_c1.get_queryset = Mock(return_value=self.doc_c1_qs)
 

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -39,6 +39,7 @@ class CarDocument(DocType):
         fields = ['name', 'price']
         model = Car
         index = 'car_index'
+        related_models = [Manufacturer]
 
 
 class DocTypeTestCase(TestCase):
@@ -72,6 +73,10 @@ class DocTypeTestCase(TestCase):
             set(mapping.properties.properties.to_dict().keys()),
             set(['color', 'name', 'price', 'type'])
         )
+
+    def test_related_models_added(self):
+        related_models = CarDocument._doc_type.related_models
+        self.assertEqual([Manufacturer], related_models)
 
     def test_duplicate_field_names_not_allowed(self):
         with self.assertRaises(RedeclaredFieldError):

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -15,31 +15,26 @@ class DocumentRegistryTestCase(TestCase):
     class ModelC():
         pass
 
+    def _generate_doc_mock(self, model, index=None, ignore_signals=False, related_models=None):
+        doc = Mock()
+        doc._doc_type.model = model
+        doc._doc_type.ignore_signals = ignore_signals
+        doc._doc_type.related_models = related_models if related_models is not None else []
+
+        if index:
+            self.registry.register(index, doc)
+
+        return doc
+
     def setUp(self):
         self.registry = DocumentRegistry()
         self.index_1 = Mock()
         self.index_2 = Mock()
 
-        self.doc_a1 = Mock()
-        self.doc_a1._doc_type.model = self.ModelA
-        self.doc_a1._doc_type.ignore_signals = False
-
-        self.doc_a2 = Mock()
-        self.doc_a2._doc_type.model = self.ModelA
-        self.doc_a2._doc_type.ignore_signals = False
-
-        self.doc_b1 = Mock()
-        self.doc_b1._doc_type.model = self.ModelB
-        self.doc_b1._doc_type.ignore_signals = False
-
-        self.doc_c1 = Mock()
-        self.doc_c1._doc_type.model = self.ModelC
-        self.doc_c1._doc_type.ignore_signals = False
-
-        self.registry.register(self.index_1, self.doc_a1)
-        self.registry.register(self.index_1, self.doc_a2)
-        self.registry.register(self.index_2, self.doc_b1)
-        self.registry.register(self.index_1, self.doc_c1)
+        self.doc_a1 = self._generate_doc_mock(self.ModelA, self.index_1)
+        self.doc_a2 = self._generate_doc_mock(self.ModelA, self.index_1)
+        self.doc_b1 = self._generate_doc_mock(self.ModelB, self.index_2)
+        self.doc_c1 = self._generate_doc_mock(self.ModelC, self.index_1)
 
     def test_empty_registry(self):
         registry = DocumentRegistry()
@@ -87,11 +82,7 @@ class DocumentRegistryTestCase(TestCase):
         self.assertFalse(self.registry.get_indices([ModelC]))
 
     def test_update_instance(self):
-        doc_a3 = Mock()
-        doc_a3._doc_type.model = self.ModelA
-        doc_a3._doc_type.ignore_signals = True
-
-        self.registry.register(self.index_1, doc_a3)
+        doc_a3 = self._generate_doc_mock(self.ModelA, self.index_1, ignore_signals=True)
 
         instance = self.ModelA()
         self.registry.update(instance)
@@ -101,12 +92,26 @@ class DocumentRegistryTestCase(TestCase):
         self.doc_a1.update.assert_called_once_with(instance)
         self.doc_a2.update.assert_called_once_with(instance)
 
-    def test_delete_instance(self):
-        doc_a3 = Mock()
-        doc_a3._doc_type.model = self.ModelA
-        doc_a3._doc_type.ignore_signals = True
+    def test_update_related_instances(self):
+        class ModelD():
+            pass
 
-        self.registry.register(self.index_1, doc_a3)
+        class ModelE():
+            pass
+
+        doc_d1 = self._generate_doc_mock(ModelD, self.index_1, related_models=[ModelE])
+
+        instance = ModelE()
+        related_instance = ModelD()
+
+        doc_d1.get_instances_from_related.return_value = related_instance
+        self.registry.update(instance)
+
+        doc_d1.get_instances_from_related.assert_called_once_with(instance)
+        doc_d1.update.assert_called_once_with(related_instance)
+
+    def test_delete_instance(self):
+        doc_a3 = self._generate_doc_mock(self.ModelA, self.index_1, ignore_signals=True)
 
         instance = self.ModelA()
         self.registry.delete(instance)

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -110,6 +110,23 @@ class DocumentRegistryTestCase(TestCase):
         doc_d1.get_instances_from_related.assert_called_once_with(instance)
         doc_d1.update.assert_called_once_with(related_instance)
 
+    def test_update_related_isntances_not_defined(self):
+        class ModelD():
+            pass
+
+        class ModelE():
+            pass
+
+        doc_d1 = self._generate_doc_mock(ModelD, self.index_1, related_models=[ModelE])
+
+        instance = ModelE()
+
+        doc_d1.get_instances_from_related.return_value = None
+        self.registry.update(instance)
+
+        doc_d1.get_instances_from_related.assert_called_once_with(instance)
+        doc_d1.update.assert_not_called()
+
     def test_delete_instance(self):
         doc_a3 = self._generate_doc_mock(self.ModelA, self.index_1, ignore_signals=True)
 


### PR DESCRIPTION
If you include data from related models in your Elasticsearch documents, you will probably need to update the documents whenever the related models are updated as well. Previously, this did not happen automatically.

This change allows you to automatically update an Elasticsearch document if a related model is updated. Simply add a list of model classes to the Meta class as `related_models` to update, and define a `get_instances_from_related` method to map the related models to models of the doc type to update.

I'm not sure about the mapping method part and I would appreciate some thoughts on that, but otherwise I think this is a useful addition.