### PR TITLE
Consistent title level in docs (HISTORY.rst)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@ History
 -------
 
 0.2.0 (2017-02-07)
-++++++++++++++++++
+~~~~~~~~~~~~~~~~~~
 
 * Replace simple model signals with easier to customise signal processors (barseghyanartur)
 * Add options to disable automatic index refreshes (HansAdema)
@@ -12,6 +12,6 @@ History
 * Add option to set default Index settings through Django config (HansAdema)
 
 0.1.0 (2017-26-05)
-++++++++++++++++++
+~~~~~~~~~~~~~~~~~~
 
 * First release on PyPI.


### PR DESCRIPTION
This trivial change should fix the ugly PyPI formatting.