### PR TITLE
Strings are dead, long live strings!

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -361,7 +361,7 @@ So for example you can use a custom analyzer_:
     class CarDocument(DocType):
         description = fields.TextField(
             analyzer=html_strip,
-            fields={'raw': fields.StringField(index='not_analyzed')}
+            fields={'raw': fields.KeywordField()}
         )
 
         class Meta:

--- a/README.rst
+++ b/README.rst
@@ -217,7 +217,7 @@ like this:
     class CarDocument(DocType):
         # add a string field to the Elasticsearch mapping called type, the
         # value of which is derived from the model's type_to_string attribute
-        type = fields.StringField(attr="type_to_string")
+        type = fields.TextField(attr="type_to_string")
 
         class Meta:
             model = Car
@@ -301,12 +301,12 @@ You can use an ObjectField or a NestedField.
     @car.doc_type
     class CarDocument(DocType):
         manufacturer = fields.ObjectField(properties={
-            'name': fields.StringField(),
-            'country_code': fields.StringField(),
+            'name': fields.TextField(),
+            'country_code': fields.TextField(),
         })
         ads = fields.NestedField(properties={
-            'description': fields.StringField(analyzer=html_strip),
-            'title': fields.StringField(),
+            'description': fields.TextField(analyzer=html_strip),
+            'title': fields.TextField(),
             'pk': fields.IntegerField(),
         })
 
@@ -359,7 +359,7 @@ So for example you can use a custom analyzer_:
 
     @car.doc_type
     class CarDocument(DocType):
-        description = fields.StringField(
+        description = fields.TextField(
             analyzer=html_strip,
             fields={'raw': fields.StringField(index='not_analyzed')}
         )
@@ -448,7 +448,7 @@ want to put in this Elasticsearch index.
             fields = [
                 'name', # If a field as the same name in multiple DocType of
                         # the same Index, the field type must be identical
-                        # (here fields.StringField)
+                        # (here fields.TextField)
                 'country_code',
             ]
 

--- a/django_elasticsearch_dsl/documents.py
+++ b/django_elasticsearch_dsl/documents.py
@@ -19,7 +19,7 @@ from .fields import (
     IntegerField,
     LongField,
     ShortField,
-    StringField,
+    TextField,
 )
 from .indices import Index
 from .registries import registry
@@ -29,23 +29,23 @@ model_field_class_to_field_class = {
     models.AutoField: IntegerField,
     models.BigIntegerField: LongField,
     models.BooleanField: BooleanField,
-    models.CharField: StringField,
+    models.CharField: TextField,
     models.DateField: DateField,
     models.DateTimeField: DateField,
-    models.EmailField: StringField,
+    models.EmailField: TextField,
     models.FileField: FileField,
-    models.FilePathField: StringField,
+    models.FilePathField: TextField,
     models.FloatField: DoubleField,
     models.ImageField: FileField,
     models.IntegerField: IntegerField,
     models.NullBooleanField: BooleanField,
     models.PositiveIntegerField: IntegerField,
     models.PositiveSmallIntegerField: ShortField,
-    models.SlugField: StringField,
+    models.SlugField: TextField,
     models.SmallIntegerField: ShortField,
-    models.TextField: StringField,
+    models.TextField: TextField,
     models.TimeField: LongField,
-    models.URLField: StringField,
+    models.URLField: TextField,
 }
 
 

--- a/example/test_app/documents.py
+++ b/example/test_app/documents.py
@@ -76,7 +76,7 @@ class ManufacturerDocument(DocType):
 class AdDocument(DocType):
     description = fields.TextField(
         analyzer=html_strip,
-        fields={'raw': fields.StringField(index='not_analyzed')}
+        fields={'raw': fields.KeywordField()}
     )
 
     class Meta:

--- a/example/test_app/documents.py
+++ b/example/test_app/documents.py
@@ -22,19 +22,19 @@ html_strip = analyzer(
 @car.doc_type
 class CarDocument(DocType):
     manufacturer = fields.ObjectField(properties={
-        'name': fields.StringField(),
-        'country': fields.StringField(),
+        'name': fields.TextField(),
+        'country': fields.TextField(),
         'logo': fields.FileField(),
     })
 
     ads = fields.NestedField(properties={
-        'description': fields.StringField(analyzer=html_strip),
-        'title': fields.StringField(),
+        'description': fields.TextField(analyzer=html_strip),
+        'title': fields.TextField(),
         'pk': fields.IntegerField(),
     })
 
     categories = fields.NestedField(properties={
-        'title': fields.StringField(),
+        'title': fields.TextField(),
     })
 
     class Meta:
@@ -61,7 +61,7 @@ class CarDocument(DocType):
 
 @car.doc_type
 class ManufacturerDocument(DocType):
-    country = fields.StringField()
+    country = fields.TextField()
 
     class Meta:
         model = Manufacturer
@@ -74,7 +74,7 @@ class ManufacturerDocument(DocType):
 
 
 class AdDocument(DocType):
-    description = fields.StringField(
+    description = fields.TextField(
         analyzer=html_strip,
         fields={'raw': fields.StringField(index='not_analyzed')}
     )

--- a/tests/documents.py
+++ b/tests/documents.py
@@ -80,7 +80,7 @@ ad_index.settings(
 class AdDocument(DocType):
     description = fields.TextField(
         analyzer=html_strip,
-        fields={'raw': fields.StringField(index='not_analyzed')}
+        fields={'raw': fields.KeywordField()}
     )
 
     class Meta:

--- a/tests/documents.py
+++ b/tests/documents.py
@@ -26,19 +26,19 @@ class CarDocument(DocType):
         super(CarDocument, self).__init__(*args, **kwargs)
 
     manufacturer = fields.ObjectField(properties={
-        'name': fields.StringField(),
-        'country': fields.StringField(),
+        'name': fields.TextField(),
+        'country': fields.TextField(),
     })
 
     ads = fields.NestedField(properties={
-        'description': fields.StringField(analyzer=html_strip),
-        'title': fields.StringField(),
+        'description': fields.TextField(analyzer=html_strip),
+        'title': fields.TextField(),
         'pk': fields.IntegerField(),
     })
 
     categories = fields.NestedField(properties={
-        'title': fields.StringField(),
-        'slug': fields.StringField(),
+        'title': fields.TextField(),
+        'slug': fields.TextField(),
         'icon': fields.FileField(),
     })
 
@@ -57,7 +57,7 @@ class CarDocument(DocType):
 
 @car_index.doc_type
 class ManufacturerDocument(DocType):
-    country = fields.StringField()
+    country = fields.TextField()
 
     class Meta:
         model = Manufacturer
@@ -78,7 +78,7 @@ ad_index.settings(
 
 @ad_index.doc_type
 class AdDocument(DocType):
-    description = fields.StringField(
+    description = fields.TextField(
         analyzer=html_strip,
         fields={'raw': fields.StringField(index='not_analyzed')}
     )

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -113,13 +113,13 @@ class DocTypeTestCase(TestCase):
                 'car_document': {
                     'properties': {
                         'name': {
-                            'type': 'string'
+                            'type': 'text'
                         },
                         'color': {
-                            'type': 'string'
+                            'type': 'text'
                         },
                         'type': {
-                            'type': 'string'
+                            'type': 'text'
                         },
                         'price': {
                             'type': 'double'

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -29,8 +29,8 @@ class Manufacturer(models.Model):
 
 
 class CarDocument(DocType):
-    color = fields.StringField()
-    type = fields.StringField()
+    color = fields.TextField()
+    type = fields.TextField()
 
     def prepare_color(self, instance):
         return "blue"
@@ -89,8 +89,8 @@ class DocTypeTestCase(TestCase):
     def test_duplicate_field_names_not_allowed(self):
         with self.assertRaises(RedeclaredFieldError):
             class CarDocument(DocType):
-                color = fields.StringField()
-                name = fields.StringField()
+                color = fields.TextField()
+                name = fields.TextField()
 
                 class Meta:
                     fields = ['name']
@@ -99,7 +99,7 @@ class DocTypeTestCase(TestCase):
     def test_to_field(self):
         doc = DocType()
         nameField = doc.to_field('name', Car._meta.get_field('name'))
-        self.assertIsInstance(nameField, fields.StringField)
+        self.assertIsInstance(nameField, fields.TextField)
         self.assertEqual(nameField._path, ['name'])
 
     def test_to_field_with_unknown_field(self):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -22,7 +22,7 @@ from django_elasticsearch_dsl.fields import (
     NestedField,
     ObjectField,
     ShortField,
-    StringField,
+    TextField,
 )
 from django_elasticsearch_dsl.exceptions import VariableLookupError
 
@@ -75,22 +75,22 @@ class DEDFieldTestCase(TestCase):
 class ObjectFieldTestCase(TestCase):
     def test_get_mapping(self):
         field = ObjectField(attr='person', properties={
-            'first_name': StringField(analyzer='foo'),
-            'last_name': StringField()
+            'first_name': TextField(analyzer='foo'),
+            'last_name': TextField()
         })
 
         self.assertEqual({
             'type': 'object',
             'properties': {
-                'first_name': {'type': 'string', 'analyzer': 'foo'},
-                'last_name': {'type': 'string'},
+                'first_name': {'type': 'text', 'analyzer': 'foo'},
+                'last_name': {'type': 'text'},
             }
         }, field.to_dict())
 
     def test_get_value_from_instance(self):
         field = ObjectField(attr='person', properties={
-            'first_name': StringField(analyzier='foo'),
-            'last_name': StringField()
+            'first_name': TextField(analyzier='foo'),
+            'last_name': TextField()
         })
 
         instance = NonCallableMock(person=NonCallableMock(
@@ -103,8 +103,8 @@ class ObjectFieldTestCase(TestCase):
 
     def test_get_value_from_instance_with_inner_objectfield(self):
         field = ObjectField(attr='person', properties={
-            'first_name': StringField(analyzier='foo'),
-            'last_name': StringField(),
+            'first_name': TextField(analyzier='foo'),
+            'last_name': TextField(),
             'aditional': ObjectField(properties={
                 'age': IntegerField()
             })
@@ -123,8 +123,8 @@ class ObjectFieldTestCase(TestCase):
 
     def test_get_value_from_instance_with_none_inner_objectfield(self):
         field = ObjectField(attr='person', properties={
-            'first_name': StringField(analyzier='foo'),
-            'last_name': StringField(),
+            'first_name': TextField(analyzier='foo'),
+            'last_name': TextField(),
             'aditional': ObjectField(properties={
                 'age': IntegerField()
             })
@@ -143,8 +143,8 @@ class ObjectFieldTestCase(TestCase):
 
     def test_get_value_from_iterable(self):
         field = ObjectField(attr='person', properties={
-            'first_name': StringField(analyzier='foo'),
-            'last_name': StringField()
+            'first_name': TextField(analyzier='foo'),
+            'last_name': TextField()
         })
 
         instance = NonCallableMock(
@@ -173,15 +173,15 @@ class ObjectFieldTestCase(TestCase):
 class NestedFieldTestCase(TestCase):
     def test_get_mapping(self):
         field = NestedField(attr='person', properties={
-            'first_name': StringField(analyzer='foo'),
-            'last_name': StringField()
+            'first_name': TextField(analyzer='foo'),
+            'last_name': TextField()
         })
 
         self.assertEqual({
             'type': 'nested',
             'properties': {
-                'first_name': {'type': 'string', 'analyzer': 'foo'},
-                'last_name': {'type': 'string'},
+                'first_name': {'type': 'text', 'analyzer': 'foo'},
+                'last_name': {'type': 'text'},
             }
         }, field.to_dict())
 
@@ -204,12 +204,12 @@ class DateFieldTestCase(TestCase):
         }, field.to_dict())
 
 
-class StringFieldTestCase(TestCase):
+class TextFieldTestCase(TestCase):
     def test_get_mapping(self):
-        field = StringField()
+        field = TextField()
 
         self.assertEqual({
-            'type': 'string',
+            'type': 'text',
         }, field.to_dict())
 
 
@@ -287,16 +287,16 @@ class IpFieldTestCase(TestCase):
 
 class ListFieldTestCase(TestCase):
     def test_get_mapping(self):
-        field = ListField(StringField(attr='foo.bar'))
+        field = ListField(TextField(attr='foo.bar'))
         self.assertEqual({
-            'type': 'string',
+            'type': 'text',
         }, field.to_dict())
 
     def test_get_value_from_instance(self):
         instance = NonCallableMock(
             foo=NonCallableMock(bar=["alpha", "beta", "gamma"])
         )
-        field = ListField(StringField(attr='foo.bar'))
+        field = ListField(TextField(attr='foo.bar'))
         self.assertEqual(
             field.get_value_from_instance(instance), instance.foo.bar)
 
@@ -323,7 +323,7 @@ class FileFieldTestCase(TestCase):
     def test_get_mapping(self):
         field = FileField()
         self.assertEqual({
-            'type': 'string',
+            'type': 'text',
         }, field.to_dict())
 
     def test_get_value_from_instance(self):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -191,10 +191,10 @@ class IntegrationTestCase(ESTestCase, TestCase):
             'manufacturer_document': {
                 'properties': {
                     'created': {'type': 'date'},
-                    'name': {'type': 'string'},
-                    'country': {'type': 'string'},
-                    'country_code': {'type': 'string'},
-                    'logo': {'type': 'string'},
+                    'name': {'type': 'text'},
+                    'country': {'type': 'text'},
+                    'country_code': {'type': 'text'},
+                    'logo': {'type': 'text'},
                 }
             },
             'car_document': {
@@ -203,31 +203,31 @@ class IntegrationTestCase(ESTestCase, TestCase):
                         'type': 'nested',
                         'properties': {
                             'description': {
-                                'type': 'string', 'analyzer':
+                                'type': 'text', 'analyzer':
                                 'html_strip'
                             },
                             'pk': {'type': 'integer'},
-                            'title': {'type': 'string'},
+                            'title': {'type': 'text'},
                         },
                     },
                     'categories': {
                         'type': 'nested',
                         'properties': {
-                            'title': {'type': 'string'},
-                            'slug': {'type': 'string'},
-                            'icon': {'type': 'string'},
+                            'title': {'type': 'text'},
+                            'slug': {'type': 'text'},
+                            'icon': {'type': 'text'},
                         },
                     },
                     'manufacturer': {
                         'type': 'object',
                         'properties': {
-                            'country': {'type': 'string'},
-                            'name': {'type': 'string'},
+                            'country': {'type': 'text'},
+                            'name': {'type': 'text'},
                         },
                     },
-                    'name': {'type': 'string'},
+                    'name': {'type': 'text'},
                     'launched': {'type': 'date'},
-                    'type': {'type': 'string'},
+                    'type': {'type': 'text'},
                 }
             }
         })


### PR DESCRIPTION
Elasticsearch 5.0 removes the string type, replacing them with text and keyword types.

https://www.elastic.co/blog/strings-are-dead-long-live-strings