### PR TITLE
Implement ActionBuffer to speed up runtime indexing

### DIFF
--- a/django_elasticsearch_dsl/actions.py
+++ b/django_elasticsearch_dsl/actions.py
@@ -1,0 +1,115 @@
+from itertools import chain
+
+from collections import defaultdict
+
+from django.core.paginator import Paginator
+from django.db.models import Model
+from elasticsearch.helpers import bulk
+from six import iteritems
+
+from .apps import DEDConfig
+
+
+class ActionBuffer(object):
+    """
+    ActionBuffer helps to gather index/delete actions and send them in bulk.
+    """
+
+    def __init__(self, registry=None):
+        if registry:
+            self._registry = registry
+        else:
+            self._registry = self._get_default_registry()
+
+        self._actions = defaultdict(set)
+
+    def _get_default_registry(self):
+        # Import the registry locally to avoid circular dependency.
+        from django_elasticsearch_dsl.registries import registry
+        return registry
+
+    def add_doc_actions(self, doc_instance, instances, action='index'):
+        """
+        Add actions to update/delete model(s) for a specific DocType.
+
+        Recommended when doing bulk updates.
+
+        :param doc_instance: The DocType instance to perform actions on.
+        :param instances: A model instance, list of models or queryset.
+        :param action: What to do with the data (index/delete).
+        """
+        if isinstance(instances, Model):
+            instances = [instances]
+
+        self._actions[doc_instance.connection].add(self._get_actions(
+            doc_instance, instances, action=action,
+        ))
+
+    def add_model_actions(self, model, action='index'):
+        """
+        Add actions to update all documents where this model is used.
+
+        :param model: A Model instance.
+        :param action: What do do with the documents (index/delete).
+        """
+        for doc in self._registry.get_documents(model.__class__):
+            self.add_doc_actions(doc(), model, action=action)
+
+        for doc in self._registry.get_related_doc(model.__class__):
+            doc_instance = doc()
+
+            related = doc_instance.get_instances_from_related(model)
+
+            if related is not None:
+                # Don't respect the original action. We just want to sync,
+                # not delete.
+                self.add_doc_actions(doc_instance, related, action='index')
+
+    def _get_actions(self, doc_type, object_list, action):
+        if doc_type._doc_type.queryset_pagination is not None:
+            paginator = Paginator(
+                object_list, doc_type._doc_type.queryset_pagination
+            )
+            for page in paginator.page_range:
+                for object_instance in paginator.page(page).object_list:
+                    yield self._prepare_action(doc_type, object_instance, action)
+        else:
+            for object_instance in object_list:
+                yield self._prepare_action(doc_type, object_instance, action)
+
+    def _prepare_action(self, doc_type, object_instance, action):
+        return {
+            '_op_type': action,
+            '_index': str(doc_type._doc_type.index),
+            '_type': doc_type._doc_type.mapping.doc_type,
+            '_id': object_instance.pk,
+            '_source': (
+                doc_type.prepare(object_instance) if action != 'delete' else None
+            ),
+        }
+
+    def execute(self, connection=None, **kwargs):
+        """
+        Send the buffered actions to Elasticsearch.
+
+        :param connection: The ES connection to send (leave empty for all).
+        :param kwargs: Additional options sent to Elasticsearch.
+        """
+        if 'refresh' not in kwargs and DEDConfig.auto_refresh_enabled():
+            kwargs['refresh'] = True
+
+        if connection:
+            return bulk(
+                client=connection,
+                actions=chain(*self._actions[connection]),
+                **kwargs
+            )
+        else:
+            for conn, actions in iteritems(self._actions):
+                bulk(client=conn, actions=chain(*actions), **kwargs)
+
+    def __len__(self):
+        return len(self._actions)
+
+    def __nonzero__(self):
+        return len(self) > 0

--- a/django_elasticsearch_dsl/actions.py
+++ b/django_elasticsearch_dsl/actions.py
@@ -3,7 +3,7 @@ from itertools import chain
 from collections import defaultdict
 
 from django.core.paginator import Paginator
-from django.db.models import Model
+from django.db.models import Model, Manager
 from elasticsearch.helpers import bulk
 from six import iteritems
 
@@ -40,6 +40,8 @@ class ActionBuffer(object):
         """
         if isinstance(instances, Model):
             instances = [instances]
+        elif isinstance(instances, Manager):
+            instances = instances.all()
 
         self._actions[doc_instance.connection].add(self._get_actions(
             doc_instance, instances, action=action,

--- a/django_elasticsearch_dsl/apps.py
+++ b/django_elasticsearch_dsl/apps.py
@@ -15,7 +15,7 @@ class DEDConfig(AppConfig):
         self.module.autodiscover()
         connections.configure(**settings.ELASTICSEARCH_DSL)
         # Setup the signal processor.
-        if not self.signal_processor:
+        if not self.signal_processor and self.autosync_enabled():
             signal_processor_path = getattr(
                 settings,
                 'ELASTICSEARCH_DSL_SIGNAL_PROCESSOR',

--- a/django_elasticsearch_dsl/registries.py
+++ b/django_elasticsearch_dsl/registries.py
@@ -1,9 +1,10 @@
 from collections import defaultdict
 from itertools import chain
 
+from django.db.models.base import ModelBase
 from django.utils.six import itervalues, iterkeys, iteritems
 
-from .apps import DEDConfig
+from .actions import ActionBuffer
 
 
 class DocumentRegistry(object):
@@ -29,54 +30,22 @@ class DocumentRegistry(object):
 
         self._indices[index].add(doc_class)
 
-    def _get_related_doc(self, instance):
-        for model in self._related_models.get(instance.__class__, []):
-            for doc in self._models[model]:
+    def get_related_doc(self, model):
+        for related_model in self._related_models.get(model, []):
+            for doc in self._models[related_model]:
                 yield doc
 
-    def update_related(self, instance, **kwargs):
+    def update(self, instance, action='index', **kwargs):
         """
-        Update docs that have related_models.
+        Update all the Elasticsearch documents attached to this model.
         """
-        if not DEDConfig.autosync_enabled():
-            return
-
-        for doc in self._get_related_doc(instance):
-            doc_instance = doc()
-            related = doc_instance.get_instances_from_related(instance)
-            if related is not None:
-                doc_instance.update(related, **kwargs)
-
-    def delete_related(self, instance, **kwargs):
-        """
-        Remove `instance` from related models.
-        """
-        if not DEDConfig.autosync_enabled():
-            return
-
-        for doc in self._get_related_doc(instance):
-            doc_instance = doc(related_instance_to_ignore=instance)
-            related = doc_instance.get_instances_from_related(instance)
-            if related is not None:
-                doc_instance.update(related, **kwargs)
-
-    def update(self, instance, **kwargs):
-        """
-        Update all the elasticsearch documents attached to this model (if their
-        ignore_signals flag allows it)
-        """
-        if not DEDConfig.autosync_enabled():
-            return
-
-        if instance.__class__ in self._models:
-            for doc in self._models[instance.__class__]:
-                if not doc._doc_type.ignore_signals:
-                    doc().update(instance, **kwargs)
+        actions = ActionBuffer(registry=self)
+        actions.add_model_actions(instance, action)
+        return actions.execute(**kwargs)
 
     def delete(self, instance, **kwargs):
         """
-        Delete all the elasticsearch documents attached to this model (if their
-        ignore_signals flag allows it)
+        Delete all the Elasticsearch documents attached to this model.
         """
         self.update(instance, action="delete", **kwargs)
 
@@ -84,10 +53,13 @@ class DocumentRegistry(object):
         """
         Get all documents in the registry or the documents for a list of models
         """
-        if models is not None:
+        if models is None:
+            return set(chain(*itervalues(self._indices)))
+        elif isinstance(models, ModelBase):
+            return set(self._models.get(models, {}))
+        else:
             return set(chain(*(self._models[model] for model in models
                                if model in self._models)))
-        return set(chain(*itervalues(self._indices)))
 
     def get_models(self):
         """

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -2,47 +2,84 @@ from mock import Mock
 
 from django.db import models
 
+from django_elasticsearch_dsl import Index
 from django_elasticsearch_dsl.documents import DocType
+from django_elasticsearch_dsl.registries import DocumentRegistry
+
+
+class ModelA(models.Model):
+    class Meta:
+        app_label = 'foo'
+
+
+class ModelB(models.Model):
+    class Meta:
+        app_label = 'foo'
+
+
+class ModelC(models.Model):
+    class Meta:
+        app_label = 'bar'
+
+
+class ModelD(models.Model):
+    pass
+
+
+class ModelE(models.Model):
+    pass
+
+
+class DocA1(DocType):
+    get_queryset = Mock(return_value=Mock())
+    update = Mock()
+    get_instances_from_related = Mock()
+
+    class Meta:
+        model = ModelA
+
+
+class DocA2(DocType):
+    get_queryset = Mock(return_value=Mock())
+    update = Mock()
+    get_instances_from_related = Mock()
+
+    class Meta:
+        model = ModelA
+
+
+class DocB1(DocType):
+    get_queryset = Mock(return_value=Mock())
+    update = Mock()
+    get_instances_from_related = Mock()
+
+    class Meta:
+        model = ModelB
+
+
+class DocC1(DocType):
+    get_queryset = Mock(return_value=Mock())
+    update = Mock()
+    get_instances_from_related = Mock()
+
+    class Meta:
+        model = ModelC
+        ignore_signals = True
+
+
+class DocD1(DocType):
+    get_queryset = Mock(return_value=Mock())
+    update = Mock()
+    get_instances_from_related = Mock(return_value=ModelD())
+
+    class Meta:
+        model = ModelD
+        related_models = [ModelE]
 
 
 class WithFixturesMixin(object):
 
-    class ModelA(models.Model):
-        class Meta:
-            app_label = 'foo'
-
-    class ModelB(models.Model):
-        class Meta:
-            app_label = 'foo'
-
-    class ModelC(models.Model):
-        class Meta:
-            app_label = 'bar'
-
-    class ModelD(models.Model):
-        pass
-
-    class ModelE(models.Model):
-        pass
-
-    def _generate_doc_mock(
-        self, _model, index=None, mock_qs=None,
-        _ignore_signals=False, _related_models=None
-    ):
-        class Doc(DocType):
-            class Meta:
-                model = _model
-                ignore_signals = _ignore_signals
-                related_models = _related_models if (
-                    _related_models) is not None else []
-
-        Doc.update = Mock()
-        if mock_qs:
-            Doc.get_queryset = Mock(return_value=mock_qs)
-        if _related_models:
-            Doc.get_instances_from_related = Mock()
-
-        if index:
-            self.registry.register(index, Doc)
-
-        return Doc
+    def setUp(self):
+        self.registry = DocumentRegistry()
+        self.index_1 = Index('index_1')
+        self.index_2 = Index('index_2')

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,0 +1,127 @@
+from itertools import chain
+from unittest import TestCase
+
+from django_elasticsearch_dsl import DocType
+from django_elasticsearch_dsl.actions import ActionBuffer
+from tests import fixtures
+from tests.models import Car
+
+
+class ActionBufferTestCase(fixtures.WithFixturesMixin, TestCase):
+
+    def setUp(self):
+        super(ActionBufferTestCase, self).setUp()
+
+        self.registry.register(self.index_1, fixtures.DocA1)
+        self.registry.register(self.index_1, fixtures.DocA2)
+        self.registry.register(self.index_1, fixtures.DocD1)
+
+        self.action_buffer = ActionBuffer(registry=self.registry)
+
+    def test_add_doc_actions(self):
+        instance = fixtures.ModelA()
+
+        self.action_buffer.add_doc_actions(
+            fixtures.DocA1(), instance, action='my_action'
+        )
+
+        self.assertEqual(1, len(self.action_buffer._actions))
+
+        self.assertEqual([{
+            '_type': 'doc_a1',
+            '_id': None,
+            '_source': {},
+            '_op_type': 'my_action',
+            '_index': 'None',
+        }], list(chain(
+            *self.action_buffer._actions[fixtures.DocA1().connection]
+        )))
+
+    def test_add_doc_actions_iterable(self):
+        instances = [fixtures.ModelA(), fixtures.ModelA()]
+
+        self.action_buffer.add_doc_actions(
+            fixtures.DocA1(), instances, action='my_action'
+        )
+
+        self.assertEqual(1, len(self.action_buffer._actions))
+
+        self.assertEqual([
+            {
+                '_type': 'doc_a1',
+                '_id': None,
+                '_source': {},
+                '_op_type': 'my_action',
+                '_index': 'None',
+            },
+            {
+                '_type': 'doc_a1',
+                '_id': None,
+                '_source': {},
+                '_op_type': 'my_action',
+                '_index': 'None',
+            },
+        ], list(chain(
+            *self.action_buffer._actions[fixtures.DocA1().connection]
+        )))
+
+    def test_add_doc_actons_with_pagination(self):
+        class CarDocument2(DocType):
+            class Meta:
+                model = Car
+                queryset_pagination = 2
+
+        car1 = Car()
+        car2 = Car()
+        car3 = Car()
+
+        self.action_buffer.add_doc_actions(CarDocument2(), [car1, car2, car3])
+
+        self.assertEqual(1, len(self.action_buffer._actions))
+
+        self.assertEqual(3, len(list(chain(
+            *self.action_buffer._actions[CarDocument2().connection]
+        ))))
+
+    def test_add_model_actions(self):
+        instance = fixtures.ModelA()
+
+        self.action_buffer.add_model_actions(instance, action='my_action')
+        self.assertEqual(1, len(self.action_buffer._actions))
+
+        self.assertEqual([
+            {
+                '_type': 'doc_a1',
+                '_id': None,
+                '_source': {},
+                '_op_type': 'my_action',
+                '_index': 'None',
+            },
+            {
+                '_type': 'doc_a2',
+                '_id': None,
+                '_source': {},
+                '_op_type': 'my_action',
+                '_index': 'None',
+            },
+        ], sorted(list(chain(
+            *self.action_buffer._actions[fixtures.DocA1().connection]
+        )), key=lambda k: k['_type']))
+
+    def test_add_model_actions_related(self):
+        instance = fixtures.ModelE()
+
+        self.action_buffer.add_model_actions(instance, action='delete')
+        self.assertEqual(1, len(self.action_buffer._actions))
+
+        self.assertEqual([
+            {
+                '_type': 'doc_d1',
+                '_id': None,
+                '_source': {},
+                '_op_type': 'index',
+                '_index': 'None',
+            },
+        ], list(chain(
+            *self.action_buffer._actions[fixtures.DocA1().connection]
+        )))

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import patch
+from mock import patch, Mock
 
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
@@ -49,6 +49,16 @@ class CarDocument(DocType):
 
 
 class DocTypeTestCase(TestCase):
+
+    def setUp(self):
+        self.buffer_patcher = patch(
+            'django_elasticsearch_dsl.documents.ActionBuffer')
+        self.action_buffer = self.buffer_patcher.start()
+        self.action_buffer().add_doc_actions = Mock()
+        self.action_buffer().execute = Mock()
+
+    def tearDown(self):
+        self.buffer_patcher.stop()
 
     def test_model_class_added(self):
         self.assertEqual(CarDocument._doc_type.model, Car)
@@ -176,28 +186,27 @@ class DocTypeTestCase(TestCase):
         doc = CarDocument()
         car = Car(name="Type 57", price=5400000.0,
                   not_indexed="not_indexex", pk=51)
-        with patch('django_elasticsearch_dsl.documents.bulk') as mock:
-            doc.update(car)
-            actions = [{
-                    '_id': car.pk,
-                    '_op_type': 'index',
-                    '_source': {
-                        'name': car.name,
-                        'price': car.price,
-                        'type': car.type(),
-                        'color': doc.prepare_color(None),
-                    },
-                    '_index': 'car_index',
-                    '_type': 'car_document'
-            }]
-            self.assertEqual(1, mock.call_count)
-            self.assertEqual(
-                actions, list(mock.call_args_list[0][1]['actions'])
-            )
-            self.assertTrue(mock.call_args_list[0][1]['refresh'])
-            self.assertEqual(
-                doc.connection, mock.call_args_list[0][1]['client']
-            )
+        doc.update(car)
+
+        self.action_buffer().add_doc_actions.assert_called_with(
+            doc, car, 'index',
+        )
+        self.action_buffer().execute.assert_called_with(
+            doc.connection, refresh=True,
+        )
+
+    def test_model_instance_delete(self):
+        doc = CarDocument()
+        car = Car(name="Type 57", price=5400000.0,
+                  not_indexed="not_indexex", pk=51)
+        doc.delete(car)
+
+        self.action_buffer().add_doc_actions.assert_called_with(
+            doc, car, 'delete',
+        )
+        self.action_buffer().execute.assert_called_with(
+            doc.connection, refresh=True,
+        )
 
     def test_model_instance_iterable_update(self):
         doc = CarDocument()
@@ -205,60 +214,24 @@ class DocTypeTestCase(TestCase):
                   not_indexed="not_indexex", pk=51)
         car2 = Car(name=_("Type 42"), price=50000.0,
                    not_indexed="not_indexex", pk=31)
-        with patch('django_elasticsearch_dsl.documents.bulk') as mock:
-            doc.update([car, car2], action='update')
-            actions = [{
-                    '_id': car.pk,
-                    '_op_type': 'update',
-                    '_source': {
-                        'name': car.name,
-                        'price': car.price,
-                        'type': car.type(),
-                        'color': doc.prepare_color(None),
-                    },
-                    '_index': 'car_index',
-                    '_type': 'car_document'
-                },
-                {
-                    '_id': car2.pk,
-                    '_op_type': 'update',
-                    '_source': {
-                        'name': car2.name,
-                        'price': car2.price,
-                        'type': car2.type(),
-                        'color': doc.prepare_color(None),
-                    },
-                    '_index': 'car_index',
-                    '_type': 'car_document'
-            }]
-            self.assertEqual(1, mock.call_count)
-            self.assertEqual(
-                actions, list(mock.call_args_list[0][1]['actions'])
-            )
-            self.assertTrue(mock.call_args_list[0][1]['refresh'])
-            self.assertEqual(
-                doc.connection, mock.call_args_list[0][1]['client']
-            )
+        doc.update([car, car2], action='update')
+
+        self.action_buffer().add_doc_actions.assert_called_with(
+            doc, [car, car2], 'update',
+        )
+        self.action_buffer().execute.assert_called_with(
+            doc.connection, refresh=True,
+        )
 
     def test_model_instance_update_no_refresh(self):
         doc = CarDocument()
         doc._doc_type.auto_refresh = False
         car = Car()
-        with patch('django_elasticsearch_dsl.documents.bulk') as mock:
-            doc.update(car)
-            self.assertNotIn('refresh', mock.call_args_list[0][1])
+        doc.update(car)
 
-    def test_model_instance_iterable_update_with_pagination(self):
-        class CarDocument2(DocType):
-            class Meta:
-                model = Car
-                queryset_pagination = 2
-        doc = CarDocument()
-        car1 = Car()
-        car2 = Car()
-        car3 = Car()
-        with patch('django_elasticsearch_dsl.documents.bulk') as mock:
-            doc.update([car1, car2, car3])
-            self.assertEqual(
-                3, len(list(mock.call_args_list[0][1]['actions']))
-            )
+        self.action_buffer().add_doc_actions.assert_called_with(
+            doc, car, 'index',
+        )
+        self.action_buffer().execute.assert_called_with(
+            doc.connection
+        )

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -60,6 +60,10 @@ class DEDFieldTestCase(TestCase):
             callable=Mock(return_value="bar"), attr1="foo"))
         self.assertEqual(field.get_value_from_instance(instance), "bar")
 
+    def test_get_value_from_instance_none(self):
+        field = DEDField(attr='related.callable')
+        self.assertIsNone(field.get_value_from_instance(None))
+
     def test_get_value_from_instance_with_unknown_attr(self):
         class Dummy:
             attr1 = "foo"

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -1,29 +1,38 @@
 from unittest import TestCase
-from mock import patch
 
 from django.conf import settings
+from mock import patch
 
+from django_elasticsearch_dsl import DocType
 from django_elasticsearch_dsl.indices import Index
 from django_elasticsearch_dsl.registries import DocumentRegistry
+from tests import fixtures
 
-from .fixtures import WithFixturesMixin
+
+class DocA1(DocType):
+    class Meta:
+        model = fixtures.ModelA
 
 
-class IndexTestCase(WithFixturesMixin, TestCase):
+class DocA2(DocType):
+    class Meta:
+        model = fixtures.ModelA
+
+
+class IndexTestCase(fixtures.WithFixturesMixin, TestCase):
+
     def test_documents_add_to_register(self):
         registry = DocumentRegistry()
         with patch('django_elasticsearch_dsl.indices.registry', new=registry):
             index = Index('test')
-            doc_a1 = self._generate_doc_mock(self.ModelA)
-            doc_a2 = self._generate_doc_mock(self.ModelA)
-            index.doc_type(doc_a1)
+            index.doc_type(DocA1)
             docs = list(registry.get_documents())
             self.assertEqual(len(docs), 1)
-            self.assertIs(docs[0], doc_a1)
+            self.assertIs(docs[0], DocA1)
 
-            index.doc_type(doc_a2)
+            index.doc_type(DocA2)
             docs = registry.get_documents()
-            self.assertEqual(docs, set([doc_a1, doc_a2]))
+            self.assertEqual(docs, {DocA1, DocA2})
 
     def test__str__(self):
         index = Index('test')

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,0 +1,115 @@
+from unittest import TestCase
+
+from django.db import connections
+from mock import patch
+
+from django_elasticsearch_dsl import signals
+from tests import fixtures
+
+
+class BaseSignalProcessorTestCase(fixtures.WithFixturesMixin, TestCase):
+    def setUp(self):
+        super(BaseSignalProcessorTestCase, self).setUp()
+
+        self.registry.register(self.index_1, fixtures.DocA1)
+        self.registry.register(self.index_1, fixtures.DocA2)
+        self.registry.register(self.index_2, fixtures.DocB1)
+        self.registry.register(self.index_1, fixtures.DocC1)
+        self.registry.register(self.index_1, fixtures.DocD1)
+
+        self.processor = signals.BaseSignalProcessor(connections)
+        signals.registry = self.registry
+
+        self.bulk_patcher = patch('django_elasticsearch_dsl.actions.bulk')
+        self.bulk_mock = self.bulk_patcher.start()
+
+    def tearDown(self):
+        self.bulk_patcher.stop()
+
+    def test_handle_save(self):
+        instance = fixtures.ModelD()
+        self.processor.handle_save(None, instance=instance)
+
+        self.bulk_mock.assert_called_once()
+        cargs, ckwargs = self.bulk_mock.call_args
+
+        self.assertEqual([
+            {
+                '_type': 'doc_d1',
+                '_id': None,
+                '_source': {},
+                '_op_type': 'index',
+                '_index': 'None',
+            },
+        ], list(ckwargs['actions']))
+
+        self.assertEqual(fixtures.DocD1().connection, ckwargs['client'])
+
+    def test_handle_save_related(self):
+        instance = fixtures.ModelE()
+        self.processor.handle_save(None, instance=instance)
+
+        self.bulk_mock.assert_called_once()
+        cargs, ckwargs = self.bulk_mock.call_args
+
+        self.assertEqual([
+            {
+                '_type': 'doc_d1',
+                '_id': None,
+                '_source': {},
+                '_op_type': 'index',
+                '_index': 'None',
+            },
+        ], list(ckwargs['actions']))
+
+        self.assertEqual(fixtures.DocD1().connection, ckwargs['client'])
+
+    def test_handle_save_ignore_signals(self):
+        instance = fixtures.ModelC()
+        self.processor.handle_save(None, instance=instance)
+
+        self.bulk_mock.assert_not_called()
+
+    def test_handle_delete(self):
+        instance = fixtures.ModelD()
+        self.processor.handle_delete(None, instance=instance)
+
+        self.bulk_mock.assert_called_once()
+        cargs, ckwargs = self.bulk_mock.call_args
+
+        self.assertEqual([
+            {
+                '_type': 'doc_d1',
+                '_id': None,
+                '_source': None,
+                '_op_type': 'delete',
+                '_index': 'None',
+            },
+        ], list(ckwargs['actions']))
+
+        self.assertEqual(fixtures.DocD1().connection, ckwargs['client'])
+
+    def test_handle_delete_related(self):
+        instance = fixtures.ModelE()
+        self.processor.handle_pre_delete(None, instance=instance)
+
+        self.bulk_mock.assert_called_once()
+        cargs, ckwargs = self.bulk_mock.call_args
+
+        self.assertEqual([
+            {
+                '_type': 'doc_d1',
+                '_id': None,
+                '_source': {},
+                '_op_type': 'index',
+                '_index': 'None',
+            },
+        ], list(ckwargs['actions']))
+
+        self.assertEqual(fixtures.DocD1().connection, ckwargs['client'])
+
+    def test_handle_delete_ignore_signals(self):
+        instance = fixtures.ModelC()
+        self.processor.handle_delete(None, instance=instance)
+
+        self.bulk_mock.assert_not_called()


### PR DESCRIPTION
One notable issue I have with how the DED synchronization logic works, is that it sends a a call to Elasticsearch for every single document instance. If you have a complex set of relations in a model and a signal is being triggered, it will cause many separate Elasticsearch calls which can give quite a hit to page load times.

Instead, I built `ActionBuffer` to easily combine indexing actions and send them away in a single bulk query per connection/cluster.

There are two ways to add actions to the buffer. You could use:
- `add_doc_actions`: Synchronize model(s) for a given DocType.
- `add_model_actions`: Synchronize all DocTypes for a model or iterable.

This results in a number of changes:
- Data persistence and synchronization is removed from the registry and contained in `ActionBuffer`. The registry only handles registering stuff now. `DocumentRegistry.update` and `DocumentRegistry.delete` are only kept for backwards compatibility.
- Signal specific logic is contained in the signals. Calling `DocumentRegistry.update` manually outside signals will not longer check signal flags.
- Signal performance should increase substantially for complex relation structures, as only one more ES call will be sent per signal call.
- You can directly use `ActionBuffer` to build your own, efficient model synchronization logic (any takers for Django Rest Framework integration?).