### PR TITLE
Update DED for Elasticsearch 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,49 +11,73 @@ matrix:
       python: 3.5
     - env: TOX_ENV=py35-django-18-es5 ES_APT_URL=https://artifacts.elastic.co/packages/5.x/apt
       python: 3.5
+    - env: TOX_ENV=py35-django-18-es6 ES_APT_URL=https://artifacts.elastic.co/packages/6.x/apt
+      python: 3.5
     - env:  TOX_ENV=py27-django-18-es2 ES_APT_URL=https://packages.elastic.co/elasticsearch/2.x/debian
       python: 2.7
     - env: TOX_ENV=py27-django-18-es5 ES_APT_URL=https://artifacts.elastic.co/packages/5.x/apt
+      python: 2.7
+    - env: TOX_ENV=py27-django-18-es6 ES_APT_URL=https://artifacts.elastic.co/packages/6.x/apt
       python: 2.7
     - env: TOX_ENV=py35-django-19-es2 ES_APT_URL=https://packages.elastic.co/elasticsearch/2.x/debian
       python: 3.5
     - env: TOX_ENV=py35-django-19-es5 ES_APT_URL=https://artifacts.elastic.co/packages/5.x/apt
       python: 3.5
+    - env: TOX_ENV=py35-django-19-es6 ES_APT_URL=https://artifacts.elastic.co/packages/6.x/apt
+      python: 3.5
     - env: TOX_ENV=py27-django-19-es2 ES_APT_URL=https://packages.elastic.co/elasticsearch/2.x/debian
       python: 2.7
     - env: TOX_ENV=py27-django-19-es5 ES_APT_URL=https://artifacts.elastic.co/packages/5.x/apt
+      python: 2.7
+    - env: TOX_ENV=py27-django-19-es6 ES_APT_URL=https://artifacts.elastic.co/packages/6.x/apt
       python: 2.7
     - env: TOX_ENV=py36-django-110-es2 ES_APT_URL=https://packages.elastic.co/elasticsearch/2.x/debian
       python: 3.6
     - env: TOX_ENV=py36-django-110-es5 ES_APT_URL=https://artifacts.elastic.co/packages/5.x/apt
       python: 3.6
+    - env: TOX_ENV=py36-django-110-es6 ES_APT_URL=https://artifacts.elastic.co/packages/6.x/apt
+      python: 3.6
     - env: TOX_ENV=py35-django-110-es2 ES_APT_URL=https://packages.elastic.co/elasticsearch/2.x/debian
       python: 3.5
     - env: TOX_ENV=py35-django-110-es5 ES_APT_URL=https://artifacts.elastic.co/packages/5.x/apt
+      python: 3.5
+    - env: TOX_ENV=py35-django-110-es6 ES_APT_URL=https://artifacts.elastic.co/packages/6.x/apt
       python: 3.5
     - env: TOX_ENV=py27-django-110-es2 ES_APT_URL=https://packages.elastic.co/elasticsearch/2.x/debian
       python: 2.7
     - env: TOX_ENV=py27-django-110-es5 ES_APT_URL=https://artifacts.elastic.co/packages/5.x/apt
       python: 2.7
+    - env: TOX_ENV=py27-django-110-es6 ES_APT_URL=https://artifacts.elastic.co/packages/6.x/apt
+      python: 2.7
     - env: TOX_ENV=py36-django-111-es2 ES_APT_URL=https://packages.elastic.co/elasticsearch/2.x/debian
       python: 3.6
     - env: TOX_ENV=py36-django-111-es5 ES_APT_URL=https://artifacts.elastic.co/packages/5.x/apt
+      python: 3.6
+    - env: TOX_ENV=py36-django-111-es6 ES_APT_URL=https://artifacts.elastic.co/packages/6.x/apt
       python: 3.6
     - env: TOX_ENV=py35-django-111-es2 ES_APT_URL=https://packages.elastic.co/elasticsearch/2.x/debian
       python: 3.5
     - env: TOX_ENV=py35-django-111-es5 ES_APT_URL=https://artifacts.elastic.co/packages/5.x/apt
       python: 3.5
+    - env: TOX_ENV=py35-django-111-es6 ES_APT_URL=https://artifacts.elastic.co/packages/6.x/apt
+      python: 3.5
     - env: TOX_ENV=py27-django-111-es2 ES_APT_URL=https://packages.elastic.co/elasticsearch/2.x/debian
       python: 2.7
     - env: TOX_ENV=py27-django-111-es5 ES_APT_URL=https://artifacts.elastic.co/packages/5.x/apt
+      python: 2.7
+    - env: TOX_ENV=py27-django-111-es6 ES_APT_URL=https://artifacts.elastic.co/packages/6.x/apt
       python: 2.7
     - env: TOX_ENV=py36-django-2-es2 ES_APT_URL=https://packages.elastic.co/elasticsearch/2.x/debian
       python: 3.6
     - env: TOX_ENV=py36-django-2-es5 ES_APT_URL=https://artifacts.elastic.co/packages/5.x/apt
       python: 3.6
+    - env: TOX_ENV=py36-django-2-es6 ES_APT_URL=https://artifacts.elastic.co/packages/6.x/apt
+      python: 3.6
     - env: TOX_ENV=py35-django-2-es2 ES_APT_URL=https://packages.elastic.co/elasticsearch/2.x/debian
       python: 3.5
     - env: TOX_ENV=py35-django-2-es5 ES_APT_URL=https://artifacts.elastic.co/packages/5.x/apt
+      python: 3.5
+    - env: TOX_ENV=py35-django-2-es6 ES_APT_URL=https://artifacts.elastic.co/packages/6.x/apt
       python: 3.5
 
 before_install:

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Features
 - Requirements
    - Django >= 1.8
    - Python 2.7, 3.4, 3.5, 3.6
-   - Elasticsearch >= 2.0 < 6.0
+   - Elasticsearch >= 2.0 < 7.0
 
 .. _Search: http://elasticsearch-dsl.readthedocs.io/en/stable/search_dsl.html
 
@@ -36,6 +36,9 @@ Quickstart
 Install Django Elasticsearch DSL::
 
     pip install django-elasticsearch-dsl
+
+    # Elasticsearch 6.x
+    pip install 'elasticsearch-dsl>=6.0,<7.0'
 
     # Elasticsearch 5.x
     pip install 'elasticsearch-dsl>=5.0,<6.0'

--- a/django_elasticsearch_dsl/documents.py
+++ b/django_elasticsearch_dsl/documents.py
@@ -17,9 +17,10 @@ from .fields import (
     DoubleField,
     FileField,
     IntegerField,
+    KeywordField,
     LongField,
     ShortField,
-    StringField,
+    TextField,
 )
 from .indices import Index
 from .registries import registry
@@ -29,23 +30,23 @@ model_field_class_to_field_class = {
     models.AutoField: IntegerField,
     models.BigIntegerField: LongField,
     models.BooleanField: BooleanField,
-    models.CharField: StringField,
+    models.CharField: TextField,
     models.DateField: DateField,
     models.DateTimeField: DateField,
-    models.EmailField: StringField,
+    models.EmailField: TextField,
     models.FileField: FileField,
-    models.FilePathField: StringField,
+    models.FilePathField: KeywordField,
     models.FloatField: DoubleField,
     models.ImageField: FileField,
     models.IntegerField: IntegerField,
     models.NullBooleanField: BooleanField,
     models.PositiveIntegerField: IntegerField,
     models.PositiveSmallIntegerField: ShortField,
-    models.SlugField: StringField,
+    models.SlugField: KeywordField,
     models.SmallIntegerField: ShortField,
-    models.TextField: StringField,
+    models.TextField: TextField,
     models.TimeField: LongField,
-    models.URLField: StringField,
+    models.URLField: TextField,
 }
 
 

--- a/example/test_app/documents.py
+++ b/example/test_app/documents.py
@@ -61,7 +61,7 @@ class CarDocument(DocType):
 
 @car.doc_type
 class ManufacturerDocument(DocType):
-    country = fields.StringField()
+    country = fields.TextField()
 
     class Meta:
         model = Manufacturer
@@ -74,9 +74,9 @@ class ManufacturerDocument(DocType):
 
 
 class AdDocument(DocType):
-    description = fields.StringField(
+    description = fields.TextField(
         analyzer=html_strip,
-        fields={'raw': fields.StringField(index='not_analyzed')}
+        fields={'raw': fields.KeywordField()}
     )
 
     class Meta:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 django>=1.9.6
-elasticsearch-dsl>=2.1.0,<6.0.0
+elasticsearch-dsl>=2.1.0,<7.0.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,5 @@
 bumpversion==0.5.3
 wheel==0.29.0
 django>=2.0,<2.1
-elasticsearch-dsl>=2.1.0,<6.0.0
+elasticsearch-dsl>=2.1.0,<7.0.0
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
-        'elasticsearch-dsl>=2.1.0,<6.0.0',
+        'elasticsearch-dsl>=2.1.0,<7.0.0',
     ],
     license="Apache Software License 2.0",
     zip_safe=False,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+from elasticsearch_dsl import VERSION
+
+ES_MAJOR_VERSION = VERSION[0]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -7,15 +7,17 @@ from django.test import TestCase
 from django.utils.six import StringIO
 from django.utils.translation import ugettext_lazy as _
 
+from elasticsearch_dsl import Index as DSLIndex
 from django_elasticsearch_dsl.test import ESTestCase
+from tests import ES_MAJOR_VERSION
 
 from .documents import (
     ad_index,
     AdDocument,
     car_index,
     CarDocument,
-    PaginatedAdDocument
-)
+    PaginatedAdDocument,
+    ManufacturerDocument, index_settings)
 from .models import Car, Manufacturer, Ad, Category, COUNTRIES
 
 
@@ -172,7 +174,14 @@ class IntegrationTestCase(ESTestCase, TestCase):
         })
 
     def test_index_to_dict(self):
-        index_dict = car_index.to_dict()
+        text_type = 'string' if ES_MAJOR_VERSION == 2 else 'text'
+
+        test_index = DSLIndex('test_index').settings(**index_settings)
+        test_index.doc_type(CarDocument)
+        test_index.doc_type(ManufacturerDocument)
+
+        index_dict = test_index.to_dict()
+
         self.assertEqual(index_dict['settings'], {
             'number_of_shards': 1,
             'number_of_replicas': 0,
@@ -192,10 +201,10 @@ class IntegrationTestCase(ESTestCase, TestCase):
             'manufacturer_document': {
                 'properties': {
                     'created': {'type': 'date'},
-                    'name': {'type': 'string'},
-                    'country': {'type': 'string'},
-                    'country_code': {'type': 'string'},
-                    'logo': {'type': 'string'},
+                    'name': {'type': text_type},
+                    'country': {'type': text_type},
+                    'country_code': {'type': text_type},
+                    'logo': {'type': text_type},
                 }
             },
             'car_document': {
@@ -204,31 +213,31 @@ class IntegrationTestCase(ESTestCase, TestCase):
                         'type': 'nested',
                         'properties': {
                             'description': {
-                                'type': 'string', 'analyzer':
+                                'type': text_type, 'analyzer':
                                 'html_strip'
                             },
                             'pk': {'type': 'integer'},
-                            'title': {'type': 'string'},
+                            'title': {'type': text_type},
                         },
                     },
                     'categories': {
                         'type': 'nested',
                         'properties': {
-                            'title': {'type': 'string'},
-                            'slug': {'type': 'string'},
-                            'icon': {'type': 'string'},
+                            'title': {'type': text_type},
+                            'slug': {'type': text_type},
+                            'icon': {'type': text_type},
                         },
                     },
                     'manufacturer': {
                         'type': 'object',
                         'properties': {
-                            'country': {'type': 'string'},
-                            'name': {'type': 'string'},
+                            'country': {'type': text_type},
+                            'name': {'type': text_type},
                         },
                     },
-                    'name': {'type': 'string'},
+                    'name': {'type': text_type},
                     'launched': {'type': 'date'},
-                    'type': {'type': 'string'},
+                    'type': {'type': text_type},
                 }
             }
         })

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 envlist =
-    {py27,py35,py36}-django-18-{es2,es5}
-    {py27,py35,py36}-django-19-{es2,es5}
-    {py27,py35,py36}-django-110-{es2,es5}
-    {py27,py35,py36}-django-111-{es2,es5}
-    {py35,py36}-django-2-{es2,es5}
+    {py27,py35,py36}-django-18-{es2,es5,es6}
+    {py27,py35,py36}-django-19-{es2,es5,es6}
+    {py27,py35,py36}-django-110-{es2,es5,es6}
+    {py27,py35,py36}-django-111-{es2,es5,es6}
+    {py35,py36}-django-2-{es2,es5,es6}
 
 [testenv]
 setenv =
@@ -20,6 +20,7 @@ deps =
     django-2: Django>=2.0,<2.1
     es2: elasticsearch-dsl>=2.1.0,<3.0.0
     es5: elasticsearch-dsl>=5.0.0,<6.0.0
+    es6: elasticsearch-dsl>=6.0.0,<7.0.0
     -r{toxinidir}/requirements_test.txt
 
 basepython =


### PR DESCRIPTION
By popular demand (#78) it's finally here: support for Elasticsearch 6.

The following changes were necessary:

## The string field has been removed completely.
With Elasticsearch 5, the `string` field type was deprecated (#76) in favor of separate `text` and `keyword` fields. The previous auto-mapping worked because `string` was not removed yet but that needed to be changed here.

The new auto mapping defaults are now to use `text` and `keyword` field. When using these fields with Elasticsearch DSL 2.x, a `string` field will be used instead.

## Document mapping types are going to be removed.
Document mapping types and the ability to load multiple DocTypes in a single index has been removed with Elasticsearch 6, and trying to create such indexes will throw errors. Indexes created with ES <=5 still work. The tests had to be updated to accommodate this.

[More info on the Elastic blog.](https://www.elastic.co/guide/en/elasticsearch/reference/6.1/removal-of-types.html)

## The attachment field has been removed completely.
Due to the deprecation (ES 5.x) and subsequent removal (ES 6.x) of the document mapper plugin, the Attachment field is gone as well. The ingest attachment plugin should be used instead.

I implemented a simple polyfill, but I'm not familiar enough with the plugin to verify whether this will work as expected.

## DocTypeOptions has been rewritten.
The structure of `DocTypeOptions` has been rewritten for EDSL 6, so reading object properties works slightly differently. Of course, the code is still backwards compatible.