### PR TITLE
Handle nested OneToOneField when related object doesn't exist

### DIFF
--- a/django_elasticsearch_dsl/fields.py
+++ b/django_elasticsearch_dsl/fields.py
@@ -1,6 +1,7 @@
 import collections
 from types import MethodType
 
+from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django.db.models.fields.files import FieldFile
 from django.utils.encoding import force_text
@@ -56,6 +57,8 @@ class DEDField(Field):
             ):
                 try:
                     instance = getattr(instance, attr)
+                except ObjectDoesNotExist:
+                    return None
                 except (TypeError, AttributeError):
                     try:
                         instance = instance[int(attr)]


### PR DESCRIPTION
This PR fixes the case where a nested field is a `OneToOneField` and the related object doesn't exist. Attempting to access the attribute throws a `RelatedObjectDoesNotExist` exception which causes `django-elasticsearch-dsl` to not be able to index the model.

Fix simply checks if the exception thrown is an `ObjectDoesNotExist` exception (which is a subclass of `AttributeError`) and if so returns `None` for the instance, allowing the field to be skipped when the related object doesn't exist.

Example reproduce code:

```Python
# models.py

class Car(models.Model):
    name = models.CharField()
    color = models.CharField()
    manufacturer = models.ForeignKey('Manufacturer')

class Manufacturer(models.Model):
    name = models.CharField()
    country_code = models.CharField(max_length=2)
    created = models.DateField()
    headquarters = models.OneToOneField('Headquarters')

class Headquarters(models.Model):
    city = models.CharField()

```

```Python
# documents.py

from django_elasticsearch_dsl import DocType, Index
from .models import Car

car = Index('cars')
car.settings(
    number_of_shards=1,
    number_of_replicas=0
)


@car.doc_type
class CarDocument(DocType):
    manufacturer = fields.ObjectField(properties={
        'name': fields.StringField(),
        'country_code': fields.StringField(),
        'headquarters': fields.ObjectField(properties={
            'city': fields.StringField()
        })
    })

    class Meta:
        model = Car
        fields = [
            'name',
            'color',
        ]
```