### PR TITLE
Handle ObjectDoesNotExist for related instances

### DIFF
--- a/django_elasticsearch_dsl/registries.py
+++ b/django_elasticsearch_dsl/registries.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 from itertools import chain
 
+from django.core.exceptions import ObjectDoesNotExist
 from django.utils.six import itervalues, iterkeys, iteritems
 
 from .apps import DEDConfig
@@ -43,7 +44,11 @@ class DocumentRegistry(object):
 
         for doc in self._get_related_doc(instance):
             doc_instance = doc()
-            related = doc_instance.get_instances_from_related(instance)
+            try:
+                related = doc_instance.get_instances_from_related(instance)
+            except ObjectDoesNotExist:
+                related = None
+
             if related is not None:
                 doc_instance.update(related, **kwargs)
 
@@ -56,7 +61,11 @@ class DocumentRegistry(object):
 
         for doc in self._get_related_doc(instance):
             doc_instance = doc(related_instance_to_ignore=instance)
-            related = doc_instance.get_instances_from_related(instance)
+            try:
+                related = doc_instance.get_instances_from_related(instance)
+            except ObjectDoesNotExist:
+                related = None
+
             if related is not None:
                 doc_instance.update(related, **kwargs)
 


### PR DESCRIPTION
Currently if `get_instances_from_related` raises an `RelatedObjectDoesNotExist` exception it escapes instead of being considered `related_model = None` like it should. This PR fixes that.