### PR TITLE
[WIP] Fix prepare_ functions with related

### DIFF
--- a/django_elasticsearch_dsl/documents.py
+++ b/django_elasticsearch_dsl/documents.py
@@ -151,13 +151,20 @@ class DocType(DSLDocType):
             if field._path == []:
                 field._path = [name]
 
-            prep_func = getattr(self, 'prepare_%s' % name, None)
+            prep_func = getattr(self, 'prepare_%s_with_related' % name, None)
             if prep_func:
-                field_value = prep_func(instance)
-            else:
-                field_value = field.get_value_from_instance(
-                    instance, self._related_instance_to_ignore
+                field_value = prep_func(
+                    instance,
+                    related_to_ignore=self._related_instance_to_ignore
                 )
+            else:
+                prep_func = getattr(self, 'prepare_%s' % name, None)
+                if prep_func:
+                    field_value = prep_func(instance)
+                else:
+                    field_value = field.get_value_from_instance(
+                        instance, self._related_instance_to_ignore
+                    )
 
             data[name] = field_value
 

--- a/django_elasticsearch_dsl/registries.py
+++ b/django_elasticsearch_dsl/registries.py
@@ -32,7 +32,8 @@ class DocumentRegistry(object):
     def _get_related_doc(self, instance):
         for model in self._related_models.get(instance.__class__, []):
             for doc in self._models[model]:
-                yield doc
+                if instance.__class__ in doc._doc_type.related_models:
+                    yield doc
 
     def update_related(self, instance, **kwargs):
         """

--- a/tests/documents.py
+++ b/tests/documents.py
@@ -115,14 +115,7 @@ class CarWithPrepareDocument(DocType):
         return {}
 
     def get_instances_from_related(self, related_instance):
-        if isinstance(related_instance, Manufacturer):
-            return related_instance.car_set.all()
-
-    # FIXME the prepare function used with a related list can't correctly
-    # handle the delete operation if used in related_models.
-    # So don't use it.
-    # def prepare_ads(self, ads):
-    #     pass
+        return related_instance.car_set.all()
 
 
 

--- a/tests/documents.py
+++ b/tests/documents.py
@@ -78,6 +78,54 @@ class ManufacturerDocument(DocType):
         ]
 
 
+class CarWithPrepareDocument(DocType):
+    manufacturer = fields.ObjectField(properties={
+        'name': fields.StringField(),
+        'country': fields.StringField(),
+    })
+
+    manufacturer_short = fields.ObjectField(properties={
+        'name': fields.StringField(),
+    })
+
+    class Meta:
+        model = Car
+        related_models = [Manufacturer]
+        index = 'car_with_prepare_index'
+        fields = [
+            'name',
+            'launched',
+            'type',
+        ]
+
+    def prepare_manufacturer_with_related(self, car, related_to_ignore):
+        if (car.manufacturer is not None and car.manufacturer !=
+                related_to_ignore):
+            return {
+                'name': car.manufacturer.name,
+                'country': car.manufacturer.country(),
+            }
+        return {}
+
+    def prepare_manufacturer_short(self, car):
+        if car.manufacturer is not None:
+            return {
+                'name': car.manufacturer.name,
+            }
+        return {}
+
+    def get_instances_from_related(self, related_instance):
+        if isinstance(related_instance, Manufacturer):
+            return related_instance.car_set.all()
+
+    # FIXME the prepare function used with a related list can't correctly
+    # handle the delete operation if used in related_models.
+    # So don't use it.
+    # def prepare_ads(self, ads):
+    #     pass
+
+
+
 ad_index = Index('test_ads').settings(**index_settings)
 
 

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -79,19 +79,38 @@ class DocumentRegistryTestCase(WithFixturesMixin, TestCase):
 
     def test_update_related_instances(self):
         doc_d1 = self._generate_doc_mock(
+            self.ModelD, self.index_1,
+            _related_models=[self.ModelE, self.ModelB]
+        )
+        doc_d2 = self._generate_doc_mock(
             self.ModelD, self.index_1, _related_models=[self.ModelE]
         )
 
-        instance = self.ModelE()
+        instance_e = self.ModelE()
+        instance_b = self.ModelB()
         related_instance = self.ModelD()
 
+        doc_d2.get_instances_from_related.return_value = related_instance
         doc_d1.get_instances_from_related.return_value = related_instance
-        self.registry.update_related(instance)
+        self.registry.update_related(instance_e)
 
-        doc_d1.get_instances_from_related.assert_called_once_with(instance)
+        doc_d1.get_instances_from_related.assert_called_once_with(instance_e)
         doc_d1.update.assert_called_once_with(related_instance)
+        doc_d2.get_instances_from_related.assert_called_once_with(instance_e)
+        doc_d2.update.assert_called_once_with(related_instance)
 
-    def test_update_related_isntances_not_defined(self):
+        doc_d1.get_instances_from_related.reset_mock()
+        doc_d1.update.reset_mock()
+        doc_d2.get_instances_from_related.reset_mock()
+        doc_d2.update.reset_mock()
+
+        self.registry.update_related(instance_b)
+        doc_d1.get_instances_from_related.assert_called_once_with(instance_b)
+        doc_d1.update.assert_called_once_with(related_instance)
+        doc_d2.get_instances_from_related.assert_not_called()
+        doc_d2.update.assert_not_called()
+
+    def test_update_related_instances_not_defined(self):
         doc_d1 = self._generate_doc_mock(
             self.ModelD, self.index_1, _related_models=[self.ModelE]
         )


### PR DESCRIPTION
If the prepare_ function on a document use a models
from the Meta.related_models it doesn't manage when
the related_models is deleted. Add a new prepare_X_with_related
that take another param `related_instance_to_ignore` which represent
the related_model being deleted. If this models instance is used in
the prepare_ function we now avoid to return it.

See #64