### PR TITLE
Add Decimal Field to model to field mapping

### DIFF
--- a/django_elasticsearch_dsl/documents.py
+++ b/django_elasticsearch_dsl/documents.py
@@ -33,6 +33,7 @@ model_field_class_to_field_class = {
     models.CharField: TextField,
     models.DateField: DateField,
     models.DateTimeField: DateField,
+    models.DecimalField: DoubleField,
     models.EmailField: TextField,
     models.FileField: FileField,
     models.FilePathField: KeywordField,


### PR DESCRIPTION
Ran into an issue recently where I had to re-declare a Decimal Field (which I feel is frequently used). I was unsure about the need of creating an entirely different ```Field``` for Decimal so right now, it simply uses Double. 