### PR TITLE
Queryset pagination order and verbosity

### DIFF
--- a/django_elasticsearch_dsl/documents.py
+++ b/django_elasticsearch_dsl/documents.py
@@ -69,7 +69,8 @@ class DocType(DSLDocument):
         """
         Return the queryset that should be indexed by this doc type.
         """
-        return self.django.model._default_manager.all()
+        primary_key_field_name = self.django.model_meta.pk.name
+        return self.django.model._default_manager.all().order_by(primary_key_field_name)
 
     def prepare(self, instance):
         """

--- a/django_elasticsearch_dsl/documents.py
+++ b/django_elasticsearch_dsl/documents.py
@@ -206,7 +206,12 @@ class DocType(DSLDocType):
             paginator = Paginator(
                 object_list, self._doc_type.queryset_pagination
             )
+            number_of_pages = len(paginator.page_range)
+            current_page = 0
             for page in paginator.page_range:
+                current_page += 1
+                print("NUMBER OF PAGES: " + str(number_of_pages))
+                print("CURRENT PAGE: " + str(current_page))
                 for object_instance in paginator.page(page).object_list:
                     yield self._prepare_action(object_instance, action)
         else:

--- a/django_elasticsearch_dsl/documents.py
+++ b/django_elasticsearch_dsl/documents.py
@@ -211,8 +211,6 @@ class DocType(DSLDocType):
             current_page = 0
             for page in paginator.page_range:
                 current_page += 1
-                print("NUMBER OF PAGES: " + str(number_of_pages))
-                print("CURRENT PAGE: " + str(current_page))
                 for object_instance in paginator.page(page).object_list:
                     yield self._prepare_action(object_instance, action)
         else:

--- a/django_elasticsearch_dsl/documents.py
+++ b/django_elasticsearch_dsl/documents.py
@@ -137,7 +137,7 @@ class DocType(DSLDocType):
         """
         Return the queryset that should be indexed by this doc type.
         """
-        return self._doc_type.model._default_manager.all()
+        return self._doc_type.model._default_manager.all().order_by("id")
 
     def prepare(self, instance):
         """

--- a/django_elasticsearch_dsl/documents.py
+++ b/django_elasticsearch_dsl/documents.py
@@ -138,7 +138,7 @@ class DocType(DSLDocType):
         Return the queryset that should be indexed by this doc type.
         """
         primary_key_field_name = self._doc_type.model._meta.pk.name
-        return self._doc_type.model._default_manager.all().order_by(primary_key_field_name)
+        return self.django.model_default_manager.all().order_by(primary_key_field_name)
 
     def prepare(self, instance):
         """

--- a/django_elasticsearch_dsl/documents.py
+++ b/django_elasticsearch_dsl/documents.py
@@ -137,7 +137,8 @@ class DocType(DSLDocType):
         """
         Return the queryset that should be indexed by this doc type.
         """
-        return self._doc_type.model._default_manager.all().order_by("id")
+        primary_key_field_name = self._doc_type.model._meta.pk.name
+        return self._doc_type.model._default_manager.all().order_by(primary_key_field_name)
 
     def prepare(self, instance):
         """

--- a/django_elasticsearch_dsl/documents.py
+++ b/django_elasticsearch_dsl/documents.py
@@ -207,10 +207,7 @@ class DocType(DSLDocType):
             paginator = Paginator(
                 object_list, self._doc_type.queryset_pagination
             )
-            number_of_pages = len(paginator.page_range)
-            current_page = 0
             for page in paginator.page_range:
-                current_page += 1
                 for object_instance in paginator.page(page).object_list:
                     yield self._prepare_action(object_instance, action)
         else:

--- a/django_elasticsearch_dsl/documents.py
+++ b/django_elasticsearch_dsl/documents.py
@@ -69,7 +69,7 @@ class DocType(DSLDocument):
         """
         Return the queryset that should be indexed by this doc type.
         """
-        primary_key_field_name = self.django.model_meta.pk.name
+        primary_key_field_name = self.django.model._meta.pk.name
         return self.django.model._default_manager.all().order_by(primary_key_field_name)
 
     def prepare(self, instance):


### PR DESCRIPTION
Added `.order_by('id')` as was getting inconsistent results after rebuilding the index as shown in #151 

Verbosity isn't important but I liked the feature in 'django-haystack' 