### PR TITLE
Add Django 2.2 to the test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ matrix:
       python: 3.7
     - env: TOX_ENV=py37-django-21-es6
       python: 3.7
+    - env: TOX_ENV=py37-django-22-es6
+      python: 3.7
 
 cache: pip
 env:

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     {py27,py36,py37}-django-111-{es6}
     {py36,py37}-django-2-{es6}
     {py36,py37}-django-21-{es6}
+    {py36,py37}-django-22-{es6}
 
 [testenv]
 setenv =
@@ -16,6 +17,7 @@ deps =
     django-111: Django>=1.11,<2.0
     django-2: Django>=2.0,<2.1
     django-21: Django>=2.1,<2.2
+    django-22: Django>=2.2,<2.3
     es6: elasticsearch-dsl>=6.4.0,<7.0.0
     -r{toxinidir}/requirements_test.txt
 


### PR DESCRIPTION
Add Django 2.2 to the test matrix (updated pull request, since I deleted my original branch containing the change)