### PR TITLE
Import Document not DocType

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ It required to defined ``Document`` class in  ``documents.py`` in your app direc
 
     # documents.py
 
-    from django_elasticsearch_dsl import Document
+    from django_elasticsearch_dsl.documents import Document
     from django_elasticsearch_dsl.registries import registry
     from .models import Car
 
@@ -208,7 +208,8 @@ like this:
 
     # documents.py
 
-    from django_elasticsearch_dsl import Document, fields
+    from django_elasticsearch_dsl import fields
+    from django_elasticsearch_dsl.documents import Document
 
     # ... #
 
@@ -287,7 +288,8 @@ You can use an ObjectField or a NestedField.
 
     # documents.py
 
-    from django_elasticsearch_dsl import Document, fields
+    from django_elasticsearch_dsl import fields
+    from django_elasticsearch_dsl.documents import Document
     from .models import Car, Manufacturer, Ad
 
     @registry.register_document
@@ -420,7 +422,7 @@ want to put in this Elasticsearch index and also add the `registry.register_docu
 
     # documents.py
     from elasticsearch_dsl import Index
-    from django_elasticsearch_dsl import Document
+    from django_elasticsearch_dsl.documents import Document
     from .models import Car, Manufacturer
 
     # The name of your index

--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ It required to defined ``Document`` class in  ``documents.py`` in your app direc
 
     # documents.py
 
-    from django_elasticsearch_dsl.documents import Document
+    from django_elasticsearch_dsl import Document
     from django_elasticsearch_dsl.registries import registry
     from .models import Car
 
@@ -208,8 +208,7 @@ like this:
 
     # documents.py
 
-    from django_elasticsearch_dsl import fields
-    from django_elasticsearch_dsl.documents import Document
+    from django_elasticsearch_dsl import Document, fields
 
     # ... #
 
@@ -288,8 +287,7 @@ You can use an ObjectField or a NestedField.
 
     # documents.py
 
-    from django_elasticsearch_dsl import fields
-    from django_elasticsearch_dsl.documents import Document
+    from django_elasticsearch_dsl import Document, fields
     from .models import Car, Manufacturer, Ad
 
     @registry.register_document
@@ -422,7 +420,7 @@ want to put in this Elasticsearch index and also add the `registry.register_docu
 
     # documents.py
     from elasticsearch_dsl import Index
-    from django_elasticsearch_dsl.documents import Document
+    from django_elasticsearch_dsl import Document
     from .models import Car, Manufacturer
 
     # The name of your index

--- a/django_elasticsearch_dsl/__init__.py
+++ b/django_elasticsearch_dsl/__init__.py
@@ -1,6 +1,6 @@
 from django.utils.module_loading import autodiscover_modules
 
-from .documents import DocType  # noqa
+from .documents import Document  # noqa
 from .indices import Index  # noqa
 from .fields import *  # noqa
 

--- a/tests/documents.py
+++ b/tests/documents.py
@@ -1,5 +1,5 @@
 from elasticsearch_dsl import analyzer
-from django_elasticsearch_dsl import DocType, Index, fields
+from django_elasticsearch_dsl import Document, Index, fields
 from django_elasticsearch_dsl.registries import registry
 
 from .models import Ad, Category, Car, Manufacturer
@@ -19,7 +19,7 @@ html_strip = analyzer(
 
 
 @registry.register_document
-class CarDocument(DocType):
+class CarDocument(Document):
     # test can override __init__
     def __init__(self, *args, **kwargs):
         super(CarDocument, self).__init__(*args, **kwargs)
@@ -67,7 +67,7 @@ class CarDocument(DocType):
 
 
 @registry.register_document
-class ManufacturerDocument(DocType):
+class ManufacturerDocument(Document):
     country = fields.StringField()
 
     class Django:
@@ -85,7 +85,7 @@ class ManufacturerDocument(DocType):
 
 
 @registry.register_document
-class CarWithPrepareDocument(DocType):
+class CarWithPrepareDocument(Document):
     manufacturer = fields.ObjectField(properties={
         'name': fields.StringField(),
         'country': fields.StringField(),
@@ -128,7 +128,7 @@ class CarWithPrepareDocument(DocType):
 
 
 @registry.register_document
-class AdDocument(DocType):
+class AdDocument(Document):
     description = fields.TextField(
         analyzer=html_strip,
         fields={'raw': fields.KeywordField()}
@@ -149,7 +149,7 @@ class AdDocument(DocType):
 
 
 @registry.register_document
-class PaginatedAdDocument(DocType):
+class PaginatedAdDocument(Document):
 
     class Django:
         model = Ad


### PR DESCRIPTION
~I think `from django_elasticsearch_dsl import Document` is not a correct path  🤔~

just import Document not DocType