### PR TITLE
Fix wrong Django model reference in documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -468,7 +468,7 @@ want to put in this Elasticsearch index and also add the `registry.register_docu
                         'number_of_replicas': 0}
 
         class Django:
-            model = Car
+            model = Manufacturer
             fields = [
                 'name',
                 'country_code',


### PR DESCRIPTION
I guess `ManufacturerDocument` should refer to the `Manufacturer` model? As someone new to this lovely ❤️ library, this confused me a bit. 

