### PR TITLE
Fix name resolution

### DIFF
--- a/django_elasticsearch_dsl/management/commands/search_index.py
+++ b/django_elasticsearch_dsl/management/commands/search_index.py
@@ -92,7 +92,7 @@ class Command(BaseCommand):
             doc().update(qs)
 
     def _delete(self, models, options):
-        index_names = [str(index) for index in registry.get_indices(models)]
+        index_names = [index._name for index in registry.get_indices(models)]
 
         if not options['force']:
             response = input(


### PR DESCRIPTION
elasticsearch_dsl.index.Index cannot be casted to string, `_name` property should be used instead.

Otherwise you'll see this in console:
```Are you sure you want to delete the '<elasticsearch_dsl.index.Index object at 0x106d95e50>' indexes? [n/Y]: y```

Expected:
```Are you sure you want to delete the 'index_name_here' indexes? [n/Y]: y```
