### PR TITLE
Mjl index speedup

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -131,10 +131,12 @@ It required to defined ``Document`` class in  ``documents.py`` in your app direc
             # Ignore auto updating of Elasticsearch when a model is saved
             # or deleted:
             # ignore_signals = True
+
             # Don't perform an index refresh after every update (overrides global setting):
             # auto_refresh = False
+
             # Paginate the django queryset used to populate the index with the specified size
-            # (by default there is no pagination)
+            # (by default it uses the database driver's default setting)
             # queryset_pagination = 5000
 
 
@@ -550,6 +552,15 @@ Defaults to ``django_elasticsearch_dsl.signals.RealTimeSignalProcessor``.
 
 You could, for instance, make a ``CelerySignalProcessor`` which would add
 update jobs to the queue to for delayed processing.
+
+ELASTICSEARCH_DSL_PARALLEL
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Default: ``False``
+
+Run indexing (populate and rebuild) in parallel using ES' parallel_bulk() method.
+Note that some databases (e.g. sqlite) do not play well with this option.
+
 
 Testing
 -------

--- a/django_elasticsearch_dsl/documents.py
+++ b/django_elasticsearch_dsl/documents.py
@@ -150,7 +150,10 @@ class DocType(DSLDocument):
     def parallel_bulk(self, actions, **kwargs):
         if self.django.queryset_pagination and 'chunk_size' not in kwargs:
             kwargs['chunk_size'] = self.django.queryset_pagination
-        deque(parallel_bulk(client=self._get_connection(), actions=actions, **kwargs), maxlen=0)
+        bulk_actions = parallel_bulk(client=self._get_connection(), actions=actions, **kwargs)
+        # As the `parallel_bulk` is lazy, we need to get it into `deque` to run it instantly
+        # See https://discuss.elastic.co/t/helpers-parallel-bulk-in-python-not-working/39498/2
+        deque(bulk_actions, maxlen=0)
         # Fake return value to emulate bulk() since we don't have a result yet,
         # the result is currently not used upstream anyway.
         return (1, [])

--- a/django_elasticsearch_dsl/documents.py
+++ b/django_elasticsearch_dsl/documents.py
@@ -5,7 +5,6 @@ from copy import deepcopy
 from functools import partial
 
 from django import VERSION as DJANGO_VERSION
-from django.core.paginator import Paginator
 from django.db import models
 from django.utils.six import iteritems
 from elasticsearch.helpers import bulk, parallel_bulk
@@ -149,6 +148,8 @@ class DocType(DSLDocument):
         return bulk(client=self._get_connection(), actions=actions, **kwargs)
 
     def parallel_bulk(self, actions, **kwargs):
+        if self.django.queryset_pagination and 'chunk_size' not in kwargs:
+            kwargs['chunk_size'] = self.django.queryset_pagination
         deque(parallel_bulk(client=self._get_connection(), actions=actions, **kwargs), maxlen=0)
         # Fake return value to emulate bulk() since we don't have a result yet,
         # the result is currently not used upstream anyway.

--- a/django_elasticsearch_dsl/documents.py
+++ b/django_elasticsearch_dsl/documents.py
@@ -53,8 +53,7 @@ class DocType(DSLDocument):
     def __init__(self, related_instance_to_ignore=None, **kwargs):
         super(DocType, self).__init__(**kwargs)
         self._related_instance_to_ignore = related_instance_to_ignore
-        if getattr(self._doc_type, '_prepared_fields', None) is None:
-            self._doc_type._prepared_fields = self.init_prepare()
+        self._prepared_fields = self.init_prepare()
 
     def __eq__(self, other):
         return id(self) == id(other)
@@ -75,10 +74,12 @@ class DocType(DSLDocument):
         """
         Return the queryset that should be indexed by this doc type.
         """
-        primary_key_field_name = self.django.model._meta.pk.name
-        return self.django.model._default_manager.all().order_by(primary_key_field_name)
+        return self.django.model._default_manager.all()
 
     def get_indexing_queryset(self):
+        """
+        Build queryset (iterator) for use by indexing.
+        """
         qs = self.get_queryset()
         kwargs = {}
         if self.django.queryset_pagination:
@@ -120,7 +121,7 @@ class DocType(DSLDocument):
         """
         data = {
             name: prep_func(instance)
-                for name, field, prep_func in self._doc_type._prepared_fields
+                for name, field, prep_func in self._prepared_fields
             }
         # print("-> %s" % data)
         return data

--- a/django_elasticsearch_dsl/documents.py
+++ b/django_elasticsearch_dsl/documents.py
@@ -51,6 +51,7 @@ model_field_class_to_field_class = {
 }
 
 class DocType(DSLDocument):
+    _prepared_fields = []
     def __init__(self, related_instance_to_ignore=None, **kwargs):
         super(DocType, self).__init__(**kwargs)
         self._related_instance_to_ignore = related_instance_to_ignore

--- a/django_elasticsearch_dsl/documents.py
+++ b/django_elasticsearch_dsl/documents.py
@@ -53,6 +53,8 @@ class DocType(DSLDocument):
     def __init__(self, related_instance_to_ignore=None, **kwargs):
         super(DocType, self).__init__(**kwargs)
         self._related_instance_to_ignore = related_instance_to_ignore
+        if getattr(self._doc_type, '_prepared_fields', None) is None:
+            self._doc_type._prepared_fields = self.init_prepare()
 
     def __eq__(self, other):
         return id(self) == id(other)
@@ -109,16 +111,13 @@ class DocType(DSLDocument):
 
             fields.append((name, field, fn))
 
-        self._doc_type._prepared_fields = fields
+        return fields
 
     def prepare(self, instance):
         """
         Take a model instance, and turn it into a dict that can be serialized
         based on the fields defined on this DocType subclass
         """
-        if getattr(self._doc_type, '_prepared_fields', None) is None:
-            self.init_prepare()
-
         data = {
             name: prep_func(instance)
                 for name, field, prep_func in self._doc_type._prepared_fields

--- a/django_elasticsearch_dsl/documents.py
+++ b/django_elasticsearch_dsl/documents.py
@@ -125,7 +125,6 @@ class DocType(DSLDocument):
             name: prep_func(instance)
                 for name, field, prep_func in self._prepared_fields
             }
-        # print("-> %s" % data)
         return data
 
     @classmethod

--- a/django_elasticsearch_dsl/documents.py
+++ b/django_elasticsearch_dsl/documents.py
@@ -1,9 +1,13 @@
 from __future__ import unicode_literals
 
+from collections import deque
+from copy import deepcopy
+from functools import partial
+
 from django.core.paginator import Paginator
 from django.db import models
 from django.utils.six import iteritems
-from elasticsearch.helpers import bulk
+from elasticsearch.helpers import bulk, parallel_bulk
 from elasticsearch_dsl import Document as DSLDocument
 
 from .exceptions import ModelFieldNotMappedError
@@ -45,7 +49,6 @@ model_field_class_to_field_class = {
     models.URLField: TextField,
 }
 
-
 class DocType(DSLDocument):
     def __init__(self, related_instance_to_ignore=None, **kwargs):
         super(DocType, self).__init__(**kwargs)
@@ -73,36 +76,54 @@ class DocType(DSLDocument):
         primary_key_field_name = self.django.model._meta.pk.name
         return self.django.model._default_manager.all().order_by(primary_key_field_name)
 
+    def get_indexing_queryset(self):
+        qs = self.get_queryset()
+        kwargs = {}
+        if self.django.queryset_pagination:
+            kwargs = {'chunk_size': self.django.queryset_pagination}
+        return qs.iterator(**kwargs)
+
+    def init_prepare(self):
+        """
+        Initialise the data model preparers once here. Extracts the preparers
+        from the model and generate a list of callables to avoid doing that
+        work on every object instance over.
+        """
+        fields = []
+        for name, field in iteritems(self._fields):
+            if not isinstance(field, DEDField):
+                continue
+
+            if not field._path:
+                field._path = [name]
+
+            prep_func = getattr(self, 'prepare_%s_with_related' % name, None)
+            if prep_func:
+                fn = partial(prep_func, related_to_ignore=self._related_instance_to_ignore)
+            else:
+                prep_func = getattr(self, 'prepare_%s' % name, None)
+                if prep_func:
+                    fn = prep_func
+                else:
+                    fn = partial(field.get_value_from_instance, field_value_to_ignore=self._related_instance_to_ignore)
+
+            fields.append((name, field, fn))
+
+        self._doc_type._prepared_fields = fields
+
     def prepare(self, instance):
         """
         Take a model instance, and turn it into a dict that can be serialized
         based on the fields defined on this DocType subclass
         """
-        data = {}
-        for name, field in iteritems(self._fields):
-            if not isinstance(field, DEDField):
-                continue
+        if getattr(self._doc_type, '_prepared_fields', None) is None:
+            self.init_prepare()
 
-            if field._path == []:
-                field._path = [name]
-
-            prep_func = getattr(self, 'prepare_%s_with_related' % name, None)
-            if prep_func:
-                field_value = prep_func(
-                    instance,
-                    related_to_ignore=self._related_instance_to_ignore
-                )
-            else:
-                prep_func = getattr(self, 'prepare_%s' % name, None)
-                if prep_func:
-                    field_value = prep_func(instance)
-                else:
-                    field_value = field.get_value_from_instance(
-                        instance, self._related_instance_to_ignore
-                    )
-
-            data[name] = field_value
-
+        data = {
+            name: prep_func(instance)
+                for name, field, prep_func in self._doc_type._prepared_fields
+            }
+        # print("-> %s" % data)
         return data
 
     @classmethod
@@ -124,6 +145,12 @@ class DocType(DSLDocument):
     def bulk(self, actions, **kwargs):
         return bulk(client=self._get_connection(), actions=actions, **kwargs)
 
+    def parallel_bulk(self, actions, **kwargs):
+        deque(parallel_bulk(client=self._get_connection(), actions=actions, **kwargs), maxlen=0)
+        # Fake return value to emulate bulk() since we don't have a result yet,
+        # the result is currently not used upstream anyway.
+        return (1, [])
+
     def _prepare_action(self, object_instance, action):
         return {
             '_op_type': action,
@@ -135,18 +162,18 @@ class DocType(DSLDocument):
         }
 
     def _get_actions(self, object_list, action):
-        if self.django.queryset_pagination is not None:
-            paginator = Paginator(
-                object_list, self.django.queryset_pagination
-            )
-            for page in paginator.page_range:
-                for object_instance in paginator.page(page).object_list:
-                    yield self._prepare_action(object_instance, action)
-        else:
-            for object_instance in object_list:
-                yield self._prepare_action(object_instance, action)
+        for object_instance in object_list:
+            yield self._prepare_action(object_instance, action)
 
-    def update(self, thing, refresh=None, action='index', **kwargs):
+    def _bulk(self, *args, **kwargs):
+        """Helper for switching between normal and parallel bulk operation"""
+        parallel = kwargs.pop('parallel', False)
+        if parallel:
+            return self.parallel_bulk(*args, **kwargs)
+        else:
+            return self.bulk(*args, **kwargs)
+
+    def update(self, thing, refresh=None, action='index', parallel=False, **kwargs):
         """
         Update each document in ES for a model, iterable of models or queryset
         """
@@ -160,8 +187,10 @@ class DocType(DSLDocument):
         else:
             object_list = thing
 
-        return self.bulk(
-            self._get_actions(object_list, action), **kwargs
+        return self._bulk(
+            self._get_actions(object_list, action),
+            parallel=parallel,
+            **kwargs
         )
 
 

--- a/django_elasticsearch_dsl/documents.py
+++ b/django_elasticsearch_dsl/documents.py
@@ -4,6 +4,7 @@ from collections import deque
 from copy import deepcopy
 from functools import partial
 
+from django import VERSION as DJANGO_VERSION
 from django.core.paginator import Paginator
 from django.db import models
 from django.utils.six import iteritems
@@ -82,7 +83,7 @@ class DocType(DSLDocument):
         """
         qs = self.get_queryset()
         kwargs = {}
-        if self.django.queryset_pagination:
+        if DJANGO_VERSION >= (2,) and self.django.queryset_pagination:
             kwargs = {'chunk_size': self.django.queryset_pagination}
         return qs.iterator(**kwargs)
 

--- a/django_elasticsearch_dsl/documents.py
+++ b/django_elasticsearch_dsl/documents.py
@@ -93,8 +93,9 @@ class DocType(DSLDocument):
         from the model and generate a list of callables to avoid doing that
         work on every object instance over.
         """
+        index_fields = getattr(self, '_fields', {})
         fields = []
-        for name, field in iteritems(self._fields):
+        for name, field in iteritems(index_fields):
             if not isinstance(field, DEDField):
                 continue
 

--- a/django_elasticsearch_dsl/management/commands/search_index.py
+++ b/django_elasticsearch_dsl/management/commands/search_index.py
@@ -64,6 +64,13 @@ class Command(BaseCommand):
             help='Run populate/rebuild update single threaded'
         )
         parser.set_defaults(parallel=getattr(settings, 'ELASTICSEARCH_DSL_PARALLEL', False))
+        parser.add_argument(
+            '--no-count',
+            action='store_false',
+            default=True,
+            dest='count',
+            help='Do not include a total count in the summary log line'
+        )
 
     def _get_models(self, args):
         """
@@ -102,7 +109,8 @@ class Command(BaseCommand):
         parallel = options['parallel']
         for doc in registry.get_documents(models):
             self.stdout.write("Indexing {} '{}' objects {}".format(
-                doc().get_queryset().count(), doc.django.model.__name__,
+                doc().get_queryset().count() if options['count'] else "all",
+                doc.django.model.__name__,
                 "(parallel)" if parallel else "")
             )
             qs = doc().get_indexing_queryset()

--- a/django_elasticsearch_dsl/test/testcases.py
+++ b/django_elasticsearch_dsl/test/testcases.py
@@ -19,11 +19,11 @@ class ESTestCase(object):
     def tearDown(self):
         pattern = re.compile(self._index_suffixe + '$')
 
-        for doc in registry.get_documents():
-            doc._index._name = pattern.sub('', doc._index._name)
-
         for index in registry.get_indices():
             index.delete(ignore=[404, 400])
             index._name = pattern.sub('', index._name)
+
+        for doc in registry.get_documents():
+            doc._index._name = pattern.sub('', doc._index._name)
 
         super(ESTestCase, self).tearDown()

--- a/example/test_app/documents.py
+++ b/example/test_app/documents.py
@@ -1,7 +1,8 @@
 from elasticsearch_dsl import analyzer
-from django_elasticsearch_dsl import DocType, Index, fields
+from django_elasticsearch_dsl import Document, Index, fields
+from django_elasticsearch_dsl.registries import registry
 
-from .models import Ad, Category, Car, Manufacturer
+from .models import Ad, Car, Manufacturer
 
 
 car = Index('test_cars')
@@ -19,8 +20,8 @@ html_strip = analyzer(
 )
 
 
-@car.doc_type
-class CarDocument(DocType):
+@registry.register_document
+class CarDocument(Document):
     manufacturer = fields.ObjectField(properties={
         'name': fields.TextField(),
         'country': fields.TextField(),
@@ -37,19 +38,16 @@ class CarDocument(DocType):
         'title': fields.TextField(),
     })
 
-    class Meta:
+    class Django:
         model = Car
-        related_models = [Ad, Manufacturer, Category]
         fields = [
             'name',
             'launched',
             'type',
         ]
 
-    def get_queryset(self):
-        return super(CarDocument, self).get_queryset().select_related(
-            'manufacturer'
-        )
+    class Index:
+        name = "car"
 
     def get_instances_from_related(self, related_instance):
         if isinstance(related_instance, Ad):
@@ -59,11 +57,11 @@ class CarDocument(DocType):
         return related_instance.car_set.all()
 
 
-@car.doc_type
-class ManufacturerDocument(DocType):
+@registry.register_document
+class ManufacturerDocument(Document):
     country = fields.TextField()
 
-    class Meta:
+    class Django:
         model = Manufacturer
         fields = [
             'name',
@@ -72,54 +70,61 @@ class ManufacturerDocument(DocType):
             'logo',
         ]
 
-
-class CarWithPrepareDocument(DocType):
-    manufacturer = fields.ObjectField(properties={
-        'name': fields.TextField(),
-        'country': fields.TextField(),
-    })
-
-    manufacturer_short = fields.ObjectField(properties={
-        'name': fields.TextField(),
-    })
-
-    class Meta:
-        model = Car
-        related_models = [Manufacturer]
-        index = 'car_with_prepare_index'
-        fields = [
-            'name',
-            'launched',
-            'type',
-        ]
-
-    def prepare_manufacturer_with_related(self, car, related_to_ignore):
-        if (car.manufacturer is not None and car.manufacturer !=
-                related_to_ignore):
-            return {
-                'name': car.manufacturer.name,
-                'country': car.manufacturer.country(),
-            }
-        return {}
-
-    def prepare_manufacturer_short(self, car):
-        if car.manufacturer is not None:
-            return {
-                'name': car.manufacturer.name,
-            }
-        return {}
-
-    def get_instances_from_related(self, related_instance):
-        return related_instance.car_set.all()
+    class Index:
+        name = "manufacturer"
 
 
-class AdDocument(DocType):
+# @registry.register_document
+# class CarWithPrepareDocument(Document):
+#     manufacturer = fields.ObjectField(properties={
+#         'name': fields.TextField(),
+#         'country': fields.TextField(),
+#     })
+#
+#     manufacturer_short = fields.ObjectField(properties={
+#         'name': fields.TextField(),
+#     })
+#
+#     class Index:
+#         name = "car_with_prepare_index"
+#
+#     class Django:
+#         model = Car
+#         related_models = [Manufacturer]
+#         fields = [
+#             'name',
+#             'launched',
+#             'type',
+#         ]
+#
+#     def prepare_manufacturer_with_related(self, car, related_to_ignore):
+#         if (car.manufacturer is not None and car.manufacturer !=
+#                 related_to_ignore):
+#             return {
+#                 'name': car.manufacturer.name,
+#                 'country': car.manufacturer.country(),
+#             }
+#         return {}
+#
+#     def prepare_manufacturer_short(self, car):
+#         if car.manufacturer is not None:
+#             return {
+#                 'name': car.manufacturer.name,
+#             }
+#         return {}
+#
+#     def get_instances_from_related(self, related_instance):
+#         return related_instance.car_set.all()
+
+
+@registry.register_document
+class AdDocument(Document):
     description = fields.TextField(
         analyzer=html_strip,
         fields={'raw': fields.KeywordField()}
     )
 
-    class Meta:
+    class Django:
         model = Ad
         index = 'test_ads'
         fields = [
@@ -129,14 +134,21 @@ class AdDocument(DocType):
             'url',
         ]
 
+    class Index:
+        name = "add"
 
-class AdDocument2(DocType):
+
+@registry.register_document
+class AdDocument2(Document):
     def __init__(self, *args, **kwargs):
         super(AdDocument2, self).__init__(*args, **kwargs)
 
-    class Meta:
+    class Django:
         model = Ad
         index = 'test_ads2'
         fields = [
             'title',
         ]
+
+    class Index:
+        name = "add2"

--- a/tests/documents.py
+++ b/tests/documents.py
@@ -148,25 +148,5 @@ class AdDocument(Document):
         settings = index_settings
 
 
-@registry.register_document
-class PaginatedAdDocument(Document):
-
-    class Django:
-        model = Ad
-        queryset_pagination = 2
-        fields = [
-            'title',
-            'created',
-            'modified',
-            'url',
-        ]
-
-    class Index:
-        name = 'ad_index'
-
-    def get_queryset(self):
-        return Ad.objects.all().order_by('-id')
-
-
 ad_index = AdDocument._index
 car_index = CarDocument._index

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -112,7 +112,8 @@ class SearchIndexTestCase(WithFixturesMixin, TestCase):
 
     def test_populate_all_doc_type(self):
         call_command('search_index', stdout=self.out, action='populate')
-        self.doc_a1.get_queryset.assert_called_once()
+        # One call for "Indexing NNN documents", one for indexing itself (via get_index_queryset).
+        assert self.doc_a1.get_queryset.call_count == 2
         self.doc_a1.update.assert_called_once_with(self.doc_a1_qs)
         self.doc_a2.get_queryset.assert_called_once()
         self.doc_a2.update.assert_called_once_with(self.doc_a2_qs)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -114,13 +114,13 @@ class SearchIndexTestCase(WithFixturesMixin, TestCase):
         call_command('search_index', stdout=self.out, action='populate')
         # One call for "Indexing NNN documents", one for indexing itself (via get_index_queryset).
         assert self.doc_a1.get_queryset.call_count == 2
-        self.doc_a1.update.assert_called_once_with(self.doc_a1_qs)
-        self.doc_a2.get_queryset.assert_called_once()
-        self.doc_a2.update.assert_called_once_with(self.doc_a2_qs)
-        self.doc_b1.get_queryset.assert_called_once()
-        self.doc_b1.update.assert_called_once_with(self.doc_b1_qs)
-        self.doc_c1.get_queryset.assert_called_once()
-        self.doc_c1.update.assert_called_once_with(self.doc_c1_qs)
+        self.doc_a1.update.assert_called_once_with(self.doc_a1_qs.iterator(), parallel=False)
+        assert self.doc_a2.get_queryset.call_count == 2
+        self.doc_a2.update.assert_called_once_with(self.doc_a2_qs.iterator(), parallel=False)
+        assert self.doc_b1.get_queryset.call_count == 2
+        self.doc_b1.update.assert_called_once_with(self.doc_b1_qs.iterator(), parallel=False)
+        assert self.doc_c1.get_queryset.call_count == 2
+        self.doc_c1.update.assert_called_once_with(self.doc_c1_qs.iterator(), parallel=False)
 
     def test_rebuild_indices(self):
 

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -280,8 +280,8 @@ class DocTypeTestCase(TestCase):
             self.assertEqual(
                 3, len(list(mock_bulk.call_args_list[0][1]['actions']))
             )
-            self.assertEqual(mock_bulk.call_count, 1, "bulk is no called")
-            self.assertEqual(mock_parallel_bulk.call_count, 0, "parallel bulk is no called")
+            self.assertEqual(mock_bulk.call_count, 1, "bulk is called")
+            self.assertEqual(mock_parallel_bulk.call_count, 0, "parallel bulk is not called")
 
     def test_model_instance_iterable_update_with_parallel(self):
         class CarDocument2(DocType):

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -336,4 +336,6 @@ class DocTypeTestCase(TestCase):
         # preparing no access to _fields should happen
         with patch.object(CarDocument, '_fields', 33):
             d.prepare(m)
-        self.assertEqual([tuple(x) for x in m.method_calls], [('type', (), {}), ('name', (), {}), ('price', (), {})])
+        self.assertEqual(sorted([tuple(x) for x in m.method_calls], key=lambda _: _[0]),
+                         [('name', (), {}),  ('price', (), {}), ('type', (), {})]
+        )

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -305,17 +305,21 @@ class DocTypeTestCase(TestCase):
         self.assertEqual(len(d._prepared_fields), 4)
 
         expect = {
-            'color': ("<class 'django_elasticsearch_dsl.fields.TextField'>", "<class 'method'>"),
-            'type': ("<class 'django_elasticsearch_dsl.fields.StringField'>", "<class 'functools.partial'>"),
-            'name': ("<class 'django_elasticsearch_dsl.fields.TextField'>", "<class 'functools.partial'>"),
-            'price': ("<class 'django_elasticsearch_dsl.fields.DoubleField'>", "<class 'functools.partial'>"),
+            'color': ("<class 'django_elasticsearch_dsl.fields.TextField'>",
+                    ("<class 'method'>", "<type 'instancemethod'>")), # py3, py2
+            'type': ("<class 'django_elasticsearch_dsl.fields.StringField'>",
+                    ("<class 'functools.partial'>","<type 'functools.partial'>")),
+            'name': ("<class 'django_elasticsearch_dsl.fields.TextField'>",
+                    ("<class 'functools.partial'>","<type 'functools.partial'>")),
+            'price': ("<class 'django_elasticsearch_dsl.fields.DoubleField'>",
+                    ("<class 'functools.partial'>","<type 'functools.partial'>")),
         }
 
         for name, field, prep in d._prepared_fields:
             e = expect[name]
             self.assertEqual(str(type(field)), e[0], 'field type should be copied over')
             self.assertTrue('__call__' in dir(prep), 'prep function should be callable')
-            self.assertEqual(str(type(prep)), e[1], 'prep function is correct partial or method')
+            self.assertTrue(str(type(prep)) in e[1], 'prep function is correct partial or method')
 
     def test_init_prepare_results(self):
         """Are the results from init_prepare() actually used in prepare()?"""

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -274,9 +274,11 @@ class DocTypeTestCase(TestCase):
         car1 = Car()
         car2 = Car()
         car3 = Car()
-        with patch('django_elasticsearch_dsl.documents.bulk') as mock_bulk, \
-             patch('django_elasticsearch_dsl.documents.parallel_bulk') as mock_parallel_bulk:
-            doc.update([car1, car2, car3])
+
+        bulk = "django_elasticsearch_dsl.documents.bulk"
+        parallel_bulk = "django_elasticsearch_dsl.documents.parallel_bulk"
+        with patch(bulk) as mock_bulk, patch(parallel_bulk) as mock_parallel_bulk:
+            doc.update([car3, car2, car3])
             self.assertEqual(
                 3, len(list(mock_bulk.call_args_list[0][1]['actions']))
             )
@@ -292,8 +294,9 @@ class DocTypeTestCase(TestCase):
         car1 = Car()
         car2 = Car()
         car3 = Car()
-        with patch('django_elasticsearch_dsl.documents.bulk') as mock_bulk, \
-             patch('django_elasticsearch_dsl.documents.parallel_bulk') as mock_parallel_bulk:
+        bulk = "django_elasticsearch_dsl.documents.bulk"
+        parallel_bulk = "django_elasticsearch_dsl.documents.parallel_bulk"
+        with patch(bulk) as mock_bulk, patch(parallel_bulk) as mock_parallel_bulk:
             doc.update([car1, car2, car3], parallel=True)
             self.assertEqual(mock_bulk.call_count, 0, "bulk is not called")
             self.assertEqual(mock_parallel_bulk.call_count, 1, "parallel bulk is called")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -338,6 +338,7 @@ class IntegrationTestCase(ESTestCase, TestCase):
         self.assertEqual(qs.count(), 2)
         self.assertEqual(list(qs), [self.ad2, self.ad1])
 
+    @unittest.expectedFailure  # ripping out pagination made this fail (mjl)
     def test_queryset_pagination(self):
         ad3 = Ad(title="Ad 3",  car=self.car1)
         ad3.save()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -17,7 +17,6 @@ from .documents import (
     car_index,
     CarDocument,
     CarWithPrepareDocument,
-    PaginatedAdDocument,
     ManufacturerDocument,
     index_settings
 )
@@ -337,19 +336,19 @@ class IntegrationTestCase(ESTestCase, TestCase):
         self.assertEqual(qs.count(), 2)
         self.assertEqual(list(qs), [self.ad2, self.ad1])
 
-    @unittest.expectedFailure  # ripping out pagination made this fail (mjl)
-    def test_queryset_pagination(self):
+    def test_queryset_iterator_queries(self):
         ad3 = Ad(title="Ad 3",  car=self.car1)
         ad3.save()
         with self.assertNumQueries(1):
             AdDocument().update(Ad.objects.all())
 
-        doc = PaginatedAdDocument()
+        doc = AdDocument()
 
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(1):
             doc.update(Ad.objects.all().order_by('-id'))
             self.assertEqual(
                 set(int(instance.meta.id) for instance in
                     doc.search().query('match', title="Ad")),
                 set([ad3.pk, self.ad1.pk, self.ad2.pk])
             )
+

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -135,7 +135,6 @@ class IntegrationTestCase(ESTestCase, TestCase):
         ])
 
     def test_doc_to_dict(self):
-        self.maxDiff = None  # XXX: mjl temporary
         s = CarDocument.search().query("match", name=self.car2.name)
         result = s.execute()
         self.assertEqual(len(result), 1)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -135,6 +135,7 @@ class IntegrationTestCase(ESTestCase, TestCase):
         ])
 
     def test_doc_to_dict(self):
+        self.maxDiff = None  # XXX: mjl temporary
         s = CarDocument.search().query("match", name=self.car2.name)
         result = s.execute()
         self.assertEqual(len(result), 1)

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 envlist =
-    {py27,py36,py37}-django-110-{es6}
-    {py27,py36,py37}-django-111-{es6}
-    {py36,py37}-django-2-{es6}
-    {py36,py37}-django-21-{es6}
-    {py36,py37}-django-22-{es6}
+    {py27,py36,py37}-django-110-{es7}
+    {py27,py36,py37}-django-111-{es7}
+    {py36,py37}-django-2-{es7}
+    {py36,py37}-django-21-{es7}
+    {py36,py37}-django-22-{es7}
 
 [testenv]
 setenv =
@@ -19,6 +19,7 @@ deps =
     django-21: Django>=2.1,<2.2
     django-22: Django>=2.2,<2.3
     es6: elasticsearch-dsl>=6.4.0,<7.0.0
+    es7: elasticsearch-dsl>=7,<8
     -r{toxinidir}/requirements_test.txt
 
 basepython =


### PR DESCRIPTION
Use elasticsearch's parallel_bulk for indexing, add ELASTICSEARCH_DSL_PARALLEL default setting and parameters to management command.
Use qs.iterator() for fetching data during reindex, as this is much more memory efficient and performant.
Instead of finding out which methods to call to prepare fields, do that finagling once and cache it for subsequent model instance prepares.

See issue #154 for performance analysis and details.