### PR TITLE
Adding documentation for parallel indexing.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,7 @@ Features
 - Management commands for creating, deleting, rebuilding and populating indices.
 - Elasticsearch auto mapping from django models fields.
 - Complex field type support (ObjectField, NestedField).
+- Index fast using `parallel` indexing.
 - Requirements
 
    - Django >= 1.11

--- a/docs/source/es_index.rst
+++ b/docs/source/es_index.rst
@@ -56,3 +56,7 @@ When you execute the command::
 
 This will create two index named ``cars`` and ``manufacture``
 in Elasticsearch with appropriate mapping.
+
+** If your model have huge amount of data, its preferred to use `parallel` indexing.
+To do that, you can pass `--parallel` flag while reindexing or populating.
+**

--- a/docs/source/management.rst
+++ b/docs/source/management.rst
@@ -18,11 +18,11 @@ Populate the Elasticsearch mappings with the django models data (index need to b
 
 ::
 
-    $ search_index --populate [--models [app[.model] app[.model] ...]]
+    $ search_index --populate [--models [app[.model] app[.model] ...]] [--parallel]
 
 Recreate and repopulate the indices:
 
 ::
 
-    $ search_index --rebuild [-f] [--models [app[.model] app[.model] ...]]
+    $ search_index --rebuild [-f] [--models [app[.model] app[.model] ...]] [--parallel]
 


### PR DESCRIPTION
Parallel indexing was implemented with https://github.com/sabricot/django-elasticsearch-dsl/pull/213 but it was not in the documentation that you can pass `parallel` command while indexing. Also, we did not prefer using `parallel` while having huge amount of data. @mjl Can have a review?