### PR TITLE
Django 3.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,15 @@ matrix:
       python: 2.7
     - env: TOX_ENV=py36-django-2-es6
       python: 3.6
+    - env: TOX_ENV=py36-django-3-es6
+      python: 3.6
     - env: TOX_ENV=py37-django-2-es6
       python: 3.7
     - env: TOX_ENV=py37-django-21-es6
       python: 3.7
     - env: TOX_ENV=py37-django-22-es6
+      python: 3.7
+    - env: TOX_ENV=py37-django-3-es6
       python: 3.7
 
 cache: pip

--- a/django_elasticsearch_dsl/documents.py
+++ b/django_elasticsearch_dsl/documents.py
@@ -6,7 +6,7 @@ from functools import partial
 
 from django import VERSION as DJANGO_VERSION
 from django.db import models
-from django.utils.six import iteritems
+from six import iteritems
 from elasticsearch.helpers import bulk, parallel_bulk
 from elasticsearch_dsl import Document as DSLDocument
 

--- a/django_elasticsearch_dsl/indices.py
+++ b/django_elasticsearch_dsl/indices.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 
-from django.utils.encoding import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 from elasticsearch_dsl import Index as DSLIndex
 
 from .apps import DEDConfig

--- a/django_elasticsearch_dsl/management/commands/search_index.py
+++ b/django_elasticsearch_dsl/management/commands/search_index.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals, absolute_import
 
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
-from django.utils.six.moves import input
+from six.moves import input
 from ...registries import registry
 
 

--- a/django_elasticsearch_dsl/registries.py
+++ b/django_elasticsearch_dsl/registries.py
@@ -5,7 +5,7 @@ from itertools import chain
 
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.six import itervalues, iterkeys, iteritems
+from six import itervalues, iterkeys, iteritems
 from elasticsearch_dsl import Field, AttrDict
 
 from django_elasticsearch_dsl.exceptions import RedeclaredFieldError

--- a/example/test_app/models.py
+++ b/example/test_app/models.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-from django.utils.encoding import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 from django.db import models
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 django>=1.9.6
 elasticsearch-dsl>=7.0.0,<8.0.0
+six>=1.13.0,<2.0

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 
 from django.core.management.base import CommandError
 from django.core.management import call_command
-from django.utils.six import StringIO
+from six import StringIO
 
 from django_elasticsearch_dsl import Index
 from django_elasticsearch_dsl.management.commands.search_index import Command

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 from django.db.models.fields.files import FieldFile
-from django.utils.six import string_types
+from six import string_types
 from django.utils.translation import ugettext_lazy as _
 from mock import Mock, NonCallableMock
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -4,7 +4,7 @@ import unittest
 
 from django.core.management import call_command
 from django.test import TestCase
-from django.utils.six import StringIO
+from six import StringIO
 from django.utils.translation import ugettext_lazy as _
 
 from elasticsearch_dsl import Index as DSLIndex

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     {py36,py37}-django-2-{es7}
     {py36,py37}-django-21-{es7}
     {py36,py37}-django-22-{es7}
+    {py36,py37}-django-3-{es7}
 
 [testenv]
 setenv =
@@ -18,6 +19,7 @@ deps =
     django-2: Django>=2.0,<2.1
     django-21: Django>=2.1,<2.2
     django-22: Django>=2.2,<2.3
+    django-3: Django>=3.0,<3.1
     es6: elasticsearch-dsl>=6.4.0,<7.0.0
     es7: elasticsearch-dsl>=7,<8
     -r{toxinidir}/requirements_test.txt


### PR DESCRIPTION
Adds support for Django 3.0

Closes https://github.com/sabricot/django-elasticsearch-dsl/pull/233