### PR TITLE
Revert "Adding support for Postgresql JSONField"

### DIFF
--- a/django_elasticsearch_dsl/documents.py
+++ b/django_elasticsearch_dsl/documents.py
@@ -21,7 +21,7 @@ from .fields import (
     LongField,
     ShortField,
     TextField,
-    ObjectField)
+)
 from .search import Search
 
 model_field_class_to_field_class = {
@@ -48,16 +48,8 @@ model_field_class_to_field_class = {
     models.URLField: TextField,
 }
 
-try:
-    from django.contrib.postgres.fields import JSONField
-    model_field_class_to_field_class[JSONField] = ObjectField
-except ImportError:
-    pass
-
-
 class DocType(DSLDocument):
     _prepared_fields = []
-
     def __init__(self, related_instance_to_ignore=None, **kwargs):
         super(DocType, self).__init__(**kwargs)
         self._related_instance_to_ignore = related_instance_to_ignore

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 django>=1.9.6
 elasticsearch-dsl>=7.0.0,<8.0.0
+


### PR DESCRIPTION
Reverts sabricot/django-elasticsearch-dsl#220
Need to revert it as it does not work as expected!