### PR TITLE
Fix wrong default yes/no value in management commands

### DIFF
--- a/django_elasticsearch_dsl/management/commands/search_index.py
+++ b/django_elasticsearch_dsl/management/commands/search_index.py
@@ -122,7 +122,7 @@ class Command(BaseCommand):
         if not options['force']:
             response = input(
                 "Are you sure you want to delete "
-                "the '{}' indexes? [n/Y]: ".format(", ".join(index_names)))
+                "the '{}' indexes? [y/N]: ".format(", ".join(index_names)))
             if response.lower() != 'y':
                 self.stdout.write('Aborted')
                 return False


### PR DESCRIPTION
This is pretty straight forward, a small typo that actually made me question my sanity for a couple of runs :grin: 
The default was shown as `Y` while the actual logical default implemented is `N`