### PR TITLE
Create mappings for multiple document types in one index

### DIFF
--- a/django_elasticsearch_dsl/registries.py
+++ b/django_elasticsearch_dsl/registries.py
@@ -31,6 +31,8 @@ class DocumentRegistry(object):
         for idx, docs in iteritems(self._indices):
             if index._name == idx._name:
                 docs.add(doc_class)
+                for doc_types in index._doc_types:
+                    idx._doc_types.append(doc_types)
                 return
 
         self._indices[index].add(doc_class)

--- a/django_elasticsearch_dsl/registries.py
+++ b/django_elasticsearch_dsl/registries.py
@@ -31,9 +31,9 @@ class DocumentRegistry(object):
         for idx, docs in iteritems(self._indices):
             if index._name == idx._name:
                 docs.add(doc_class)
-                for doc_types in index._doc_types:
-                    idx._doc_types.append(doc_types)
-                return
+                if doc_class not in idx._doc_types:
+                    idx._doc_types.append(doc_class)
+                    return
 
         self._indices[index].add(doc_class)
 

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -359,7 +359,6 @@ class DocTypeTestCase(TestCase):
                          [('name', (), {}),  ('price', (), {}), ('type', (), {})]
         )
 
-
     def test_multiple_docs_in_same_index(self):
         car_doc = CarDocument()
         car_doc_mappings = car_doc._index.to_dict().get('mappings')
@@ -404,7 +403,7 @@ class DocTypeTestCase(TestCase):
             'price': {'type': 'double'},
             'gears_name': {'type': 'text'}}})
 
-        # Verify that the new field gears_name was merge to the car_doc mappings
+        # Verify the new field gears_name was merged to the car_doc mappings
         car_doc_mappings = car_doc._index.to_dict().get('mappings')
         self.assertEqual(car_doc_mappings, {'properties': {
             'color': {'type': 'text'},


### PR DESCRIPTION
With the removal of types in ES6 there is a need to create a custom type in order to search only one index as described in:
[removal-of-types](https://www.elastic.co/guide/en/elasticsearch/reference/6.0/removal-of-types.html)

The problem in the current implementation with multiple document types using the same index is that only the mappings of the first registered document type is applied when calling "python manage.py search_index --create". 
  
This pull request merges the mappings from the other document types(which use the same index) onto the index of the first registered document type.  

There was also work done in elasticsearch-dsl to merge mappings of multiple docTypes in the same index - see: 
[elasticsearch-dsl-py/issues/800](https://github.com/elastic/elasticsearch-dsl-py/issues/800)
and changes here:
[(https://github.com/elastic/elasticsearch-dsl-py/commit/11db37586b897a9313213d3bbd2c55f9ba20a90c](https://github.com/elastic/elasticsearch-dsl-py/commit/11db37586b897a9313213d3bbd2c55f9ba20a90c)
 