### PR TITLE
Make Python 3.8 the default. Add support for building for Python 3.8

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,4 +6,4 @@ sphinx:
 formats: all
 
 python:
-  version: 3.7
+  version: 3.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # Config file for automatic testing at travis-ci.org
 
 language: python
-python: 3.7
+python: 3.8
 
 dist: xenial # default "precise" distro doesn't include Java 8 for Elasticsearch 5
 
@@ -11,6 +11,8 @@ matrix:
       python: 3.6
     - env: TOX_ENV=py37-django-111-es6
       python: 3.7
+    - env: TOX_ENV=py38-django-111-es6
+      python: 3.8
     - env: TOX_ENV=py27-django-111-es6
       python: 2.7
     - env: TOX_ENV=py36-django-2-es6
@@ -23,6 +25,14 @@ matrix:
       python: 3.7
     - env: TOX_ENV=py37-django-30-es6
       python: 3.7
+    - env: TOX_ENV=py38-django-2-es6
+      python: 3.8
+    - env: TOX_ENV=py38-django-21-es6
+      python: 3.8
+    - env: TOX_ENV=py38-django-22-es6
+      python: 3.8
+    - env: TOX_ENV=py38-django-30-es6
+      python: 3.8
 
 cache: pip
 env:

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ Features
 - Requirements
 
    - Django >= 1.11
-   - Python 2.7, 3.5, 3.6, 3.7
+   - Python 2.7, 3.5, 3.6, 3.7, 3.8
 
 **Elasticsearch Compatibility:**
 The library is compatible with all Elasticsearch versions since 5.x

--- a/setup.py
+++ b/setup.py
@@ -65,5 +65,6 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py27-django-111-es7
-    {py36,py37}-django-{111,2,21,22,30}-{es7}
+    {py36,py37,py38}-django-{111,2,21,22,30}-{es7}
 
 [testenv]
 setenv =
@@ -23,3 +23,4 @@ basepython =
     py27: python2.7
     py36: python3.6
     py37: python3.7
+    py38: python3.8


### PR DESCRIPTION
This PR makes Python 3.8 the default and adds support for building Python 3.8.