### PR TITLE
Configure Elasticsearch _id dynamically from document 

### DIFF
--- a/django_elasticsearch_dsl/documents.py
+++ b/django_elasticsearch_dsl/documents.py
@@ -156,11 +156,19 @@ class DocType(DSLDocument):
         # the result is currently not used upstream anyway.
         return (1, [])
 
+    def document_id(self, object_instance):
+        """
+        The default behavior is to use the Django object's pk (id) as the 
+        elasticseach index id (_id). If needed, this method can be overloaded 
+        to change this default behavior.
+        """
+        return object_instance.pk
+
     def _prepare_action(self, object_instance, action):
         return {
             '_op_type': action,
             '_index': self._index._name,
-            '_id': object_instance.pk,
+            '_id': self.document_id(object_instance),
             '_source': (
                 self.prepare(object_instance) if action != 'delete' else None
             ),

--- a/django_elasticsearch_dsl/documents.py
+++ b/django_elasticsearch_dsl/documents.py
@@ -156,7 +156,8 @@ class DocType(DSLDocument):
         # the result is currently not used upstream anyway.
         return (1, [])
 
-    def generate_id(self, object_instance):
+    @classmethod
+    def generate_id(cls, object_instance):
         """
         The default behavior is to use the Django object's pk (id) as the 
         elasticseach index id (_id). If needed, this method can be overloaded 

--- a/django_elasticsearch_dsl/documents.py
+++ b/django_elasticsearch_dsl/documents.py
@@ -156,7 +156,7 @@ class DocType(DSLDocument):
         # the result is currently not used upstream anyway.
         return (1, [])
 
-    def document_id(self, object_instance):
+    def generate_id(self, object_instance):
         """
         The default behavior is to use the Django object's pk (id) as the 
         elasticseach index id (_id). If needed, this method can be overloaded 
@@ -168,7 +168,7 @@ class DocType(DSLDocument):
         return {
             '_op_type': action,
             '_index': self._index._name,
-            '_id': self.document_id(object_instance),
+            '_id': self.generate_id(object_instance),
             '_source': (
                 self.prepare(object_instance) if action != 'delete' else None
             ),

--- a/docs/source/fields.rst
+++ b/docs/source/fields.rst
@@ -233,3 +233,45 @@ Available Fields
 ``properties`` is a dict where the key is a field name, and the value is a field
 instance.
 
+
+Document id
+===========
+
+The elasticsearch document id (``_id``) is not strictly speaking a field, as it is not 
+part of the document itself. The default behavior of ``django_elasticsearch_dsl``
+is to use the primary key of the model as the document's id (``pk`` or ``id``).
+Nevertheless, it can sometimes be useful to change this default behavior. For this, one
+can redefine the ``document_id(self, instance)`` method of the ``Document`` class.
+
+For example, to use an article's slug as the elasticsearch ``_id`` instead of the 
+article's integer id, one could use:
+
+.. code-block:: python
+
+    # models.py
+
+    from django.db import models
+
+    class Article(models.Model):
+        # ... #
+
+        slug = models.SlugField(
+            max_length=40,
+            unique=True,
+        )
+
+        # ... #
+
+
+    # documents.py
+
+    from .models import Article
+
+    class ArticleDocument(Document):
+        class Django:
+            model = Article
+
+        # ... #
+
+        def document_id(self, article):
+            return article.slug

--- a/docs/source/fields.rst
+++ b/docs/source/fields.rst
@@ -241,7 +241,7 @@ The elasticsearch document id (``_id``) is not strictly speaking a field, as it 
 part of the document itself. The default behavior of ``django_elasticsearch_dsl``
 is to use the primary key of the model as the document's id (``pk`` or ``id``).
 Nevertheless, it can sometimes be useful to change this default behavior. For this, one
-can redefine the ``document_id(self, instance)`` method of the ``Document`` class.
+can redefine the ``generate_id(self, instance)`` method of the ``Document`` class.
 
 For example, to use an article's slug as the elasticsearch ``_id`` instead of the 
 article's integer id, one could use:
@@ -256,7 +256,7 @@ article's integer id, one could use:
         # ... #
 
         slug = models.SlugField(
-            max_length=40,
+            max_length=255,
             unique=True,
         )
 
@@ -273,5 +273,5 @@ article's integer id, one could use:
 
         # ... #
 
-        def document_id(self, article):
+        def generate_id(self, article):
             return article.slug

--- a/docs/source/fields.rst
+++ b/docs/source/fields.rst
@@ -241,7 +241,7 @@ The elasticsearch document id (``_id``) is not strictly speaking a field, as it 
 part of the document itself. The default behavior of ``django_elasticsearch_dsl``
 is to use the primary key of the model as the document's id (``pk`` or ``id``).
 Nevertheless, it can sometimes be useful to change this default behavior. For this, one
-can redefine the ``generate_id(self, instance)`` method of the ``Document`` class.
+can redefine the ``generate_id(cls, instance)`` class method of the ``Document`` class.
 
 For example, to use an article's slug as the elasticsearch ``_id`` instead of the 
 article's integer id, one could use:
@@ -273,5 +273,6 @@ article's integer id, one could use:
 
         # ... #
 
-        def generate_id(self, article):
+        @classmethod
+        def generate_id(cls, article):
             return article.slug

--- a/tests/documents.py
+++ b/tests/documents.py
@@ -172,7 +172,8 @@ class ArticleWithSlugAsIdDocument(Document):
         name = 'test_articles_with_slugs_as_doc_ids'
         settings = index_settings
 
-    def generate_id(self, article):
+    @classmethod
+    def generate_id(cls, article):
         return article.slug
 
 

--- a/tests/documents.py
+++ b/tests/documents.py
@@ -2,7 +2,7 @@ from elasticsearch_dsl import analyzer
 from django_elasticsearch_dsl import Document, Index, fields
 from django_elasticsearch_dsl.registries import registry
 
-from .models import Ad, Category, Car, Manufacturer
+from .models import Ad, Category, Car, Manufacturer, Article
 
 index_settings = {
     'number_of_shards': 1,
@@ -146,6 +146,34 @@ class AdDocument(Document):
     class Index:
         name = 'test_ads'
         settings = index_settings
+
+
+@registry.register_document
+class ArticleDocument(Document):
+    class Django:
+        model = Article
+        fields = [
+            'slug',
+        ]
+
+    class Index:
+        name = 'test_articles'
+        settings = index_settings
+
+@registry.register_document
+class ArticleWithSlugAsIdDocument(Document):
+    class Django:
+        model = Article
+        fields = [
+            'slug',
+        ]
+
+    class Index:
+        name = 'test_articles_with_slugs_as_doc_ids'
+        settings = index_settings
+
+    def generate_id(self, article):
+        return article.slug
 
 
 ad_index = AdDocument._index

--- a/tests/models.py
+++ b/tests/models.py
@@ -98,3 +98,6 @@ class Article(models.Model):
 
     class Meta:
         app_label = 'tests'
+
+    def __str__(self):
+        return self.slug

--- a/tests/models.py
+++ b/tests/models.py
@@ -87,3 +87,14 @@ class Ad(models.Model):
 
     def __str__(self):
         return self.title
+
+
+@python_2_unicode_compatible
+class Article(models.Model):
+    slug = models.CharField(
+        max_length=255,
+        unique=True,
+    )
+
+    class Meta:
+        app_label = 'tests'

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -12,6 +12,9 @@ from django_elasticsearch_dsl.exceptions import (ModelFieldNotMappedError,
 from django_elasticsearch_dsl.registries import registry
 from tests import ES_MAJOR_VERSION
 
+from .models import Article
+from .documents import ArticleDocument, ArticleWithSlugAsIdDocument
+
 
 class Car(models.Model):
     name = models.CharField(max_length=255)
@@ -346,3 +349,37 @@ class DocTypeTestCase(TestCase):
         self.assertEqual(sorted([tuple(x) for x in m.method_calls], key=lambda _: _[0]),
                          [('name', (), {}),  ('price', (), {}), ('type', (), {})]
         )
+
+    # def test_default_generate_id_is_called(self):       
+    #     article = Article(
+    #         id=124594,
+    #         slug='some-article',
+    #     )
+    #     with patch.object(DocType, 'generate_id') as patched_generate_id_method:
+    #         @registry.register_document
+    #         class ArticleDocument(DocType):
+    #             class Django:
+    #                 model = Article
+    #                 fields = [
+    #                     'slug',
+    #                 ]
+
+    #             class Index:
+    #                 name = 'test_articles'
+    #                 settings = {
+    #                     'number_of_shards': 1,
+    #                     'number_of_replicas': 0,
+    #                 }
+    #         d = ArticleDocument()
+    #         d.update(article)
+    #         patched_generate_id_method.assert_called()
+
+    # @patch.object(ArticleWithSlugAsIdDocument, 'generate_id')
+    # def test_custom_generate_id_is_called(self, mock_method):       
+    #     article = Article(
+    #         id=54218,
+    #         slug='some-article-2',
+    #     )
+    #     d = ArticleWithSlugAsIdDocument()
+    #     d.update(article)
+    #     mock_method.assert_called()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -369,7 +369,9 @@ class IntegrationTestCase(ESTestCase, TestCase):
         article.save()
 
         # assert that the document's id is the id of the Django object
-        try:
+        es_obj = ArticleDocument.get(id=obj_id)
+        self.assertEqual(es_obj._id, article.id)
+        self.assertEqual(es_obj.slug, article.slug)
             ArticleDocument.get(id=obj_id)
         except NotFoundError:
             self.fail("document with _id {} not found").format(obj_id)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -369,12 +369,11 @@ class IntegrationTestCase(ESTestCase, TestCase):
         article.save()
 
         # assert that the document's id is the id of the Django object
-        es_obj = ArticleDocument.get(id=obj_id)
-        self.assertEqual(es_obj._id, article.id)
-        self.assertEqual(es_obj.slug, article.slug)
-            ArticleDocument.get(id=obj_id)
+        try:
+            es_obj = ArticleDocument.get(id=obj_id)
         except NotFoundError:
             self.fail("document with _id {} not found").format(obj_id)
+        self.assertEqual(es_obj.slug, article.slug)
 
     def test_custom_document_id(self):
         article_slug = "my-very-first-article"
@@ -388,12 +387,11 @@ class IntegrationTestCase(ESTestCase, TestCase):
         article.save()
 
         # assert that the document's id is its the slug
-        es_obj = ArticleDocument.get(id=article_slug)
-        self.assertEqual(es_obj._id, article.article_slug)
-        self.assertEqual(es_obj.slug, article.slug)
-            ArticleWithSlugAsIdDocument.get(id=article_slug)
+        try:
+            es_obj = ArticleWithSlugAsIdDocument.get(id=article_slug)
         except NotFoundError:
             self.fail(
                 "document with _id '{}' not found: "
                 "using a custom id is broken".format(article_slug)
             )
+        self.assertEqual(es_obj.slug, article.slug)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -388,7 +388,9 @@ class IntegrationTestCase(ESTestCase, TestCase):
         article.save()
 
         # assert that the document's id is its the slug
-        try:
+        es_obj = ArticleDocument.get(id=article_slug)
+        self.assertEqual(es_obj._id, article.article_slug)
+        self.assertEqual(es_obj.slug, article.slug)
             ArticleWithSlugAsIdDocument.get(id=article_slug)
         except NotFoundError:
             self.fail(


### PR DESCRIPTION
Implements #271

CL:
- added optional method `document_id(self, instance)` to `Document` class to customize Elasticsearch document ids
- documented that in sections `fields`

I wasn't sure where to put the doc, so don't hesitate to move it around it you think it shouldn't be in this section.