### PR TITLE
Use chain.from_iterable in registries.py

### DIFF
--- a/django_elasticsearch_dsl/registries.py
+++ b/django_elasticsearch_dsl/registries.py
@@ -152,9 +152,9 @@ class DocumentRegistry(object):
         Get all documents in the registry or the documents for a list of models
         """
         if models is not None:
-            return set(chain(*(self._models[model] for model in models
-                               if model in self._models)))
-        return set(chain(*itervalues(self._indices)))
+            return set(chain.from_iterable(self._models[model] for model in models
+                                           if model in self._models))
+        return set(chain.from_iterable(itervalues(self._indices)))
 
     def get_models(self):
         """


### PR DESCRIPTION
This is a faster and more idiomatic way of using `itertools.chain`. Instead of computing all the items in the iterable and storing them in memory, they are computed one-by-one and never stored as a huge list. This can save on both runtime and memory space.